### PR TITLE
feat(profile): add profile settings page connected to user API

### DIFF
--- a/foundit-ui/app/profile/page.tsx
+++ b/foundit-ui/app/profile/page.tsx
@@ -1,0 +1,322 @@
+'use client';
+
+import Navbar from '@/components/Navbar';
+import Footer from '@/components/Footer';
+import TextInput from '@/components/TextInput';
+import { useProfileForm } from '@/hooks/useProfileForm';
+import { useLoggedInDisplayName } from '@/hooks/useLoggedInDisplayName';
+import { getLoggedInUser } from '@/utils/auth';
+import { MOCK_STUDENT_USER, formatDisplayName } from '@/constants/mockSession';
+import {
+  Box,
+  Button,
+  Flex,
+  HStack,
+  Spinner,
+  Stack,
+  Switch,
+  Text,
+} from '@chakra-ui/react';
+import { useSyncExternalStore, useState } from 'react';
+import { useRouter } from 'next/navigation';
+
+const FALLBACK_NAME = formatDisplayName(MOCK_STUDENT_USER);
+
+// Returns a primitive string so useSyncExternalStore compares by value.
+// Returning an object creates a new reference each render and causes an
+// infinite loop.
+function useLoggedInRole(): 'student' | 'security' {
+  return useSyncExternalStore(
+    () => () => {},
+    () => (getLoggedInUser()?.role === 'security' ? 'security' : 'student'),
+    () => 'student'
+  );
+}
+
+type ActiveTab = 'profile' | 'notifications';
+
+export default function ProfileSettingsPage() {
+  const router = useRouter();
+  const navVariant = useLoggedInRole();
+  const displayName = useLoggedInDisplayName(FALLBACK_NAME);
+  const [activeTab, setActiveTab] = useState<ActiveTab>('profile');
+
+  const {
+    fullName,
+    email,
+    phoneNumber,
+    setPhoneNumber,
+    allowEmailNotifications,
+    setAllowEmailNotifications,
+    isLoading,
+    isSaving,
+    saveStatus,
+    handleSave,
+    initials,
+  } = useProfileForm();
+
+  return (
+    <Box minH="100vh" display="flex" flexDirection="column" position="relative">
+      {/* Background */}
+      <Box
+        position="fixed"
+        inset={0}
+        backgroundImage="url('/bg.svg')"
+        backgroundSize="cover"
+        backgroundPosition="center"
+        backgroundRepeat="no-repeat"
+        zIndex={0}
+      />
+      <Box position="fixed" inset={0} bg="blackAlpha.700" zIndex={0} />
+
+      <Box
+        position="relative"
+        zIndex={1}
+        minH="100vh"
+        display="flex"
+        flexDirection="column"
+      >
+        <Navbar
+          variant={navVariant}
+          userName={displayName}
+          activePath="/profile"
+        />
+
+        <Box
+          flex={1}
+          display="flex"
+          alignItems="flex-start"
+          justifyContent="center"
+          px={4}
+          py={10}
+        >
+          <HStack gap={7} maxW="1000px" w="full" align="flex-start">
+            {/* Left: profile side menu */}
+            <Stack
+              bg="white"
+              rounded="md"
+              shadow="md"
+              w="240px"
+              flexShrink={0}
+              gap={0}
+              overflow="hidden"
+              p={4}
+            >
+              <Box
+                px={4}
+                py={3}
+                rounded="md"
+                cursor="pointer"
+                bg={activeTab === 'profile' ? 'blue.500' : 'transparent'}
+                _hover={{
+                  bg: activeTab === 'profile' ? 'blue.500' : 'gray.50',
+                }}
+                onClick={() => setActiveTab('profile')}
+              >
+                <Text
+                  color={activeTab === 'profile' ? 'white' : 'gray.700'}
+                  fontWeight="medium"
+                  fontSize="sm"
+                >
+                  Profile
+                </Text>
+              </Box>
+              <Box
+                px={4}
+                py={3}
+                cursor="pointer"
+                rounded="md"
+                bg={activeTab === 'notifications' ? 'blue.500' : 'transparent'}
+                _hover={{
+                  bg: activeTab === 'notifications' ? 'blue.500' : 'gray.50',
+                }}
+                onClick={() => setActiveTab('notifications')}
+              >
+                <Text
+                  color={activeTab === 'notifications' ? 'white' : 'gray.700'}
+                  fontWeight="medium"
+                  fontSize="sm"
+                >
+                  Notifications
+                </Text>
+              </Box>
+              <Box
+                px={4}
+                py={3}
+                cursor="pointer"
+                rounded="md"
+                _hover={{ bg: 'red.50' }}
+                onClick={() => router.push('/login')}
+              >
+                <Text color="red.600" fontWeight="medium" fontSize="sm">
+                  Sign out
+                </Text>
+              </Box>
+            </Stack>
+
+            {/* Right panel — switches between Profile and Notifications */}
+            <Stack bg="white" rounded="md" shadow="md" flex={1} p={10} gap={6}>
+              {activeTab === 'profile' ? (
+                <>
+                  <Text fontSize="2xl" fontWeight="bold" color="gray.900">
+                    Profile Settings
+                  </Text>
+
+                  {isLoading ? (
+                    <Flex align="center" justify="center" py={10}>
+                      <Spinner size="lg" color="blue.500" />
+                    </Flex>
+                  ) : (
+                    <>
+                      {/* Avatar + change photo */}
+                      <HStack gap={4} align="center">
+                        <Flex
+                          w="80px"
+                          h="80px"
+                          rounded="full"
+                          bg="blue.500"
+                          align="center"
+                          justify="center"
+                          flexShrink={0}
+                        >
+                          <Text color="white" fontSize="2xl" fontWeight="bold">
+                            {initials || '?'}
+                          </Text>
+                        </Flex>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          borderColor="gray.300"
+                        >
+                          Change Photo
+                        </Button>
+                      </HStack>
+
+                      {/* Form fields */}
+                      <Stack gap={5}>
+                        <TextInput
+                          id="fullName"
+                          label="Full Name"
+                          value={fullName}
+                          width="full"
+                          disabled
+                          readOnly
+                        />
+
+                        <TextInput
+                          id="email"
+                          label="Email Address"
+                          type="email"
+                          autoComplete="email"
+                          value={email}
+                          width="full"
+                          disabled
+                          readOnly
+                        />
+
+                        <TextInput
+                          id="phoneNumber"
+                          label="Phone Number"
+                          type="tel"
+                          autoComplete="tel"
+                          value={phoneNumber}
+                          width="full"
+                          onChange={(e) => setPhoneNumber(e.target.value)}
+                        />
+
+                        <HStack gap={4} align="center">
+                          <Text fontSize="sm" color="gray.700">
+                            Allow email notifications
+                          </Text>
+                          <Switch.Root
+                            colorPalette="blue"
+                            checked={allowEmailNotifications}
+                            onCheckedChange={(e: { checked: boolean }) =>
+                              setAllowEmailNotifications(e.checked)
+                            }
+                          >
+                            <Switch.HiddenInput />
+                            <Switch.Control>
+                              <Switch.Thumb />
+                            </Switch.Control>
+                          </Switch.Root>
+                        </HStack>
+                      </Stack>
+
+                      {/* Save row */}
+                      <HStack gap={4} align="center">
+                        <Button
+                          colorPalette="blue"
+                          w="157px"
+                          h="40px"
+                          rounded="md"
+                          fontSize="md"
+                          loading={isSaving}
+                          loadingText="Saving..."
+                          onClick={handleSave}
+                        >
+                          Save
+                        </Button>
+
+                        {saveStatus === 'success' && (
+                          <Text
+                            fontSize="sm"
+                            color="green.600"
+                            fontWeight="medium"
+                          >
+                            Changes saved.
+                          </Text>
+                        )}
+                        {saveStatus === 'error' && (
+                          <Text
+                            fontSize="sm"
+                            color="red.600"
+                            fontWeight="medium"
+                          >
+                            Save failed. Please try again.
+                          </Text>
+                        )}
+                      </HStack>
+                    </>
+                  )}
+                </>
+              ) : (
+                // TODO: Replace this stub once PATCH /api/users/me/notifications is implemented.
+                // Render notification preferences here (e.g. emailNotificationOptIn toggle).
+                // Current value is fetched via GET /api/users/me → response.emailNotificationOptIn
+                // and saved via PATCH /api/users/me/notifications → { emailNotificationOptIn: boolean }
+                <Flex
+                  direction="column"
+                  align="center"
+                  justify="center"
+                  gap={3}
+                  py={16}
+                  color="gray.400"
+                >
+                  <Text
+                    fontSize="2xl"
+                    fontWeight="bold"
+                    color="gray.900"
+                    alignSelf="flex-start"
+                  >
+                    Notifications
+                  </Text>
+                  <Text
+                    fontSize="sm"
+                    color="gray.500"
+                    textAlign="center"
+                    mt={8}
+                  >
+                    Notification settings are not yet available.
+                  </Text>
+                </Flex>
+              )}
+            </Stack>
+          </HStack>
+        </Box>
+
+        <Footer />
+      </Box>
+    </Box>
+  );
+}

--- a/foundit-ui/components/Navbar.tsx
+++ b/foundit-ui/components/Navbar.tsx
@@ -171,7 +171,7 @@ const navLinksByVariant: Record<
 
 /** Dropdown items shown under the user menu (student and security variants). */
 const userMenuItems: DropdownItem[] = [
-  { label: 'Settings', href: '/settings' },
+  { label: 'Profile', href: '/profile' },
   { label: 'Notifications', href: '/notifications' },
   { label: 'Sign Out', onClick: signOut, danger: true },
 ];

--- a/foundit-ui/hooks/useProfileForm.ts
+++ b/foundit-ui/hooks/useProfileForm.ts
@@ -1,0 +1,159 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { getLoggedInUser, getAccessToken } from '@/utils/auth';
+import { MOCK_STUDENT_USER, formatDisplayName } from '@/constants/mockSession';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+// TODO: Remove PLACEHOLDER once GET /api/users/me is implemented.
+// Prefill sources per field once the endpoint is live:
+//   fullName, email            → localStorage key 'user' (stored at login, read via getLoggedInUser())
+//   phoneNumber                → GET /api/users/me  → response.phone
+//   emailNotificationOptIn     → GET /api/users/me  → response.emailNotificationOptIn
+const PLACEHOLDER = {
+  fullName: formatDisplayName(MOCK_STUDENT_USER),
+  email: 'alice@myseneca.ca',
+  phoneNumber: '4161234567',
+  emailNotificationOptIn: true,
+};
+
+interface UserProfileResponse {
+  firstName: string;
+  lastName: string;
+  email: string;
+  phone: string | null;
+  emailNotificationOptIn: boolean;
+}
+
+export function useProfileForm() {
+  // Pre-seed from localStorage if available, otherwise use placeholder data
+  // so the page is viewable before the API is implemented.
+  const storedUser = getLoggedInUser();
+
+  const [fullName, setFullName] = useState(
+    storedUser
+      ? `${storedUser.firstName} ${storedUser.lastName}`.trim()
+      : PLACEHOLDER.fullName
+  );
+  const [email, setEmail] = useState(storedUser?.email ?? PLACEHOLDER.email);
+  const [phoneNumber, setPhoneNumber] = useState(PLACEHOLDER.phoneNumber);
+  const [allowEmailNotifications, setAllowEmailNotifications] = useState(
+    PLACEHOLDER.emailNotificationOptIn
+  );
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Separate saving state so the Save button can show an activity indicator
+  // independently from the initial page load.
+  const [isSaving, setIsSaving] = useState(false);
+  const [saveStatus, setSaveStatus] = useState<'idle' | 'success' | 'error'>(
+    'idle'
+  );
+
+  // On mount: fetch full profile to populate phone and notification pref.
+  // Silently falls back to defaults while GET /api/users/me returns 501.
+  useEffect(() => {
+    async function loadProfile() {
+      const token = getAccessToken();
+      if (!token) {
+        setIsLoading(false);
+        return;
+      }
+
+      try {
+        const res = await fetch(`${API_BASE}/api/users/me`, {
+          headers: { Authorization: `Bearer ${token}` },
+        });
+
+        if (res.ok) {
+          const data: UserProfileResponse = await res.json();
+          setFullName(`${data.firstName} ${data.lastName}`.trim());
+          setEmail(data.email);
+          setPhoneNumber(data.phone ?? '');
+          setAllowEmailNotifications(data.emailNotificationOptIn);
+        }
+        // 501 / 4xx — silently keep localStorage-seeded defaults
+      } catch {
+        // Network error — keep defaults
+      } finally {
+        setIsLoading(false);
+      }
+    }
+
+    loadProfile();
+  }, []);
+
+  // Called only when the user clicks Save. Sends PATCH requests to the backend.
+  const handleSave = async () => {
+    const token = getAccessToken();
+    if (!token) {
+      setSaveStatus('error');
+      return;
+    }
+
+    setIsSaving(true);
+    setSaveStatus('idle');
+
+    try {
+      const [firstName = '', ...rest] = fullName.trim().split(/\s+/);
+      const lastName = rest.join(' ') || undefined;
+
+      const [profileRes, notifRes] = await Promise.all([
+        // PATCH /api/users/me — updates firstName, lastName, phone
+        fetch(`${API_BASE}/api/users/me`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            firstName,
+            lastName,
+            phone: phoneNumber || null,
+          }),
+        }),
+        // PATCH /api/users/me/notifications — updates email notification opt-in
+        fetch(`${API_BASE}/api/users/me/notifications`, {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            emailNotificationOptIn: allowEmailNotifications,
+          }),
+        }),
+      ]);
+
+      setSaveStatus(profileRes.ok && notifRes.ok ? 'success' : 'error');
+    } catch {
+      setSaveStatus('error');
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const initials = fullName
+    .trim()
+    .split(/\s+/)
+    .map((n) => n[0] ?? '')
+    .join('')
+    .toUpperCase()
+    .slice(0, 2);
+
+  return {
+    fullName,
+    setFullName,
+    email,
+    setEmail,
+    phoneNumber,
+    setPhoneNumber,
+    allowEmailNotifications,
+    setAllowEmailNotifications,
+    isLoading,
+    isSaving,
+    saveStatus,
+    handleSave,
+    initials,
+  };
+}

--- a/foundit-ui/middleware.ts
+++ b/foundit-ui/middleware.ts
@@ -37,6 +37,15 @@ export function middleware(request: NextRequest) {
     }
   }
 
+  if (pathname.startsWith('/profile')) {
+    if (!role) {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+    if (role !== 'student' && role !== 'security' && role !== 'admin') {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+  }
+
   if (pathname.startsWith('/admin')) {
     if (!role) {
       return NextResponse.redirect(new URL('/login', request.url));
@@ -63,5 +72,7 @@ export const config = {
     '/admin/:path*',
     '/dashboard',
     '/dashboard/:path*',
+    '/profile/:path*',
+    '/profile',
   ],
 };

--- a/foundit-ui/utils/auth.ts
+++ b/foundit-ui/utils/auth.ts
@@ -80,6 +80,11 @@ export function getLoggedInUser(): LoggedInUser | null {
   }
 }
 
+export function getAccessToken(): string | null {
+  if (typeof window === 'undefined') return null;
+  return localStorage.getItem('accessToken');
+}
+
 export function getLoggedInDisplayName(): string | null {
   const user = getLoggedInUser();
   if (!user?.firstName) {


### PR DESCRIPTION
## Summary
- Adds `/profile` settings page with form fields for full name, email, phone number, and email notification opt-in
- Introduces `useProfileForm` hook that pre-seeds data from `localStorage` and fetches from `GET /api/users/me` when available; saves via `PATCH /api/users/me` and `PATCH /api/users/me/notifications`
- Protects `/profile` routes in middleware (redirects unauthenticated users to `/login`)
- Renames the Navbar user menu "Settings" link to "Profile" pointing to `/profile`

## Notes
- Full name and email fields are read-only (editing requires a dedicated endpoint)
- Notification settings tab is stubbed pending backend implementation
- Gracefully falls back to `localStorage`-seeded defaults while `GET /api/users/me` returns 501

## Test plan
- [ ] Unauthenticated visit to `/profile` redirects to `/login`
- [ ] Logged-in student/security user can navigate to `/profile` via the navbar user menu
- [ ] Profile page pre-fills name and email from `localStorage` on load
- [ ] Phone number field is editable; Save button triggers PATCH requests and shows success/error feedback
- [ ] Email notification toggle persists on save
- [ ] Notifications tab renders the "not yet available" stub

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Profile Settings page accessible from the user menu, enabling users to update their personal information including phone number and manage email notification preferences.

* **Navigation Updates**
  * Updated the user dropdown menu to include a direct "Profile" link, replacing the previous "Settings" option.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->