### PR TITLE
feat(report-found): token-keyed found-item report form

### DIFF
--- a/foundit-ui/app/report-found/[token]/page.tsx
+++ b/foundit-ui/app/report-found/[token]/page.tsx
@@ -1,0 +1,452 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { useParams } from 'next/navigation';
+import {
+  Box,
+  Button,
+  Flex,
+  HStack,
+  Heading,
+  Spinner,
+  Stack,
+  Text,
+} from '@chakra-ui/react';
+import Navbar from '@/components/Navbar';
+import Footer from '@/components/Footer';
+import FormTextInput from '@/components/FormTextInput';
+import SelectInput from '@/components/SelectInput';
+import TextAreaInput from '@/components/TextAreaInput';
+import ImageUploadGallery from '@/components/uploadImage';
+import { LuCircleAlert } from 'react-icons/lu';
+import { CATEGORIES } from '@/constants/categories';
+import { CAMPUSES } from '@/constants/campuses';
+import { useReportFoundItemForm } from '@/hooks/useReportFoundItemForm';
+import { useLoggedInDisplayName } from '@/hooks/useLoggedInDisplayName';
+import { getAccessToken, getLoggedInUser } from '@/utils/auth';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+// ─── NOTES FOR THE TEAM ──────────────────────────────────────────────────────
+// Wired to existing teammate utils:
+//   • utils/auth.ts        → getAccessToken (upload + submit Bearer),
+//                            getLoggedInUser (identity rows + student gate)
+//   • constants/campuses.ts→ CAMPUSES (Campus stub options)
+//   • components/uploadImage.tsx (ImageUploadGallery) + its hook/util chain
+//
+// Still stubbed / needs backend work (kept UI-only for now):
+//   1. Contact Information + Campus — rendered for design parity but NOT sent.
+//      • Contact: no column on found_item_report; closest is user.phone (a
+//        profile field on the user table, not a per-report contact).
+//      • Campus: campusId exists on report_link/user/item (not on the report).
+//        The submit route already DERIVES + validates it from the link, so this
+//        picker is display-only. See the hook's STUB FIELDS note.
+//   2. Finder / Registrant rows — both fall back to the logged-in user. The link
+//      carries no finder identity, and the backend records the submitter as the
+//      finder. Decide the real source (e.g. link should carry the finder name).
+//   3. Campus name can't be resolved from validate().campusId — that's a UUID,
+//      but constants/campuses.ts uses slug ids. Needs a campuses lookup endpoint
+//      to display the link's actual campus.
+//   4. Images are uploaded to R2 on select but never linked to the report (the
+//      submit schema has no image field) → orphaned objects. Also needs an R2
+//      CORS policy for http://localhost:3000 before uploads work locally.
+// ─────────────────────────────────────────────────────────────────────────────
+
+type ValidateReason = 'available' | 'not_found' | 'used' | 'expired';
+
+interface ValidateResult {
+  valid: boolean;
+  reason: ValidateReason;
+  campusId: string | null;
+  expiresAt?: string;
+  usedAt?: string;
+}
+
+type LinkState =
+  | { status: 'loading' }
+  | { status: 'error' }
+  | { status: 'ready'; result: ValidateResult };
+
+export default function ReportFoundItemPage() {
+  const params = useParams<{ token: string }>();
+  const token = params?.token ?? '';
+  const displayName = useLoggedInDisplayName('');
+  const [linkState, setLinkState] = useState<LinkState>({ status: 'loading' });
+
+  useEffect(() => {
+    let active = true;
+
+    async function run() {
+      if (!token) {
+        setLinkState({ status: 'error' });
+        return;
+      }
+
+      try {
+        const res = await fetch(
+          `${API_BASE}/api/report-links/${token}/validate`
+        );
+        if (!res.ok) {
+          if (active) setLinkState({ status: 'error' });
+          return;
+        }
+        const result = (await res.json()) as ValidateResult;
+        if (active) setLinkState({ status: 'ready', result });
+      } catch {
+        if (active) setLinkState({ status: 'error' });
+      }
+    }
+
+    run();
+    return () => {
+      active = false;
+    };
+  }, [token]);
+
+  return (
+    <PageShell displayName={displayName}>
+      {linkState.status === 'loading' && (
+        <Flex align="center" justify="center" py={20} w="full">
+          <Spinner size="lg" color="blue.500" />
+        </Flex>
+      )}
+
+      {linkState.status === 'error' && (
+        <MessageCard
+          title="Something went wrong"
+          body="We couldn't check this report link. Please try again later."
+        />
+      )}
+
+      {linkState.status === 'ready' &&
+        linkState.result.reason !== 'available' && (
+          <MessageCard {...unavailableCopy(linkState.result.reason)} />
+        )}
+
+      {linkState.status === 'ready' &&
+        linkState.result.reason === 'available' && (
+          <ReportForm token={token} displayName={displayName} />
+        )}
+    </PageShell>
+  );
+}
+
+function unavailableCopy(reason: ValidateReason): {
+  title: string;
+  body: string;
+} {
+  switch (reason) {
+    case 'used':
+      return {
+        title: 'Link already used',
+        body: 'This report link has already been used to submit a found item.',
+      };
+    case 'expired':
+      return {
+        title: 'Link expired',
+        body: 'This report link has expired. Please ask security for a new one.',
+      };
+    case 'not_found':
+    default:
+      return {
+        title: 'Invalid link',
+        body: "This report link is invalid or doesn't exist.",
+      };
+  }
+}
+
+function PageShell({
+  displayName,
+  children,
+}: {
+  displayName: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <Box minH="100vh" display="flex" flexDirection="column" position="relative">
+      <Box
+        position="fixed"
+        inset={0}
+        backgroundImage="url('/bg.svg')"
+        backgroundSize="cover"
+        backgroundPosition="center"
+        backgroundRepeat="no-repeat"
+        zIndex={0}
+      />
+      <Box position="fixed" inset={0} bg="blackAlpha.700" zIndex={0} />
+
+      <Box
+        position="relative"
+        zIndex={1}
+        minH="100vh"
+        display="flex"
+        flexDirection="column"
+      >
+        <Navbar
+          variant="student"
+          userName={displayName || undefined}
+          activePath="/report-found"
+        />
+
+        <Box
+          flex={1}
+          display="flex"
+          alignItems="flex-start"
+          justifyContent="center"
+          px={4}
+          py={10}
+        >
+          {children}
+        </Box>
+
+        <Footer />
+      </Box>
+    </Box>
+  );
+}
+
+function ReadonlyRow({ label, value }: { label: string; value: string }) {
+  return (
+    <HStack align="flex-start" gap={4}>
+      <Text
+        w="180px"
+        flexShrink={0}
+        fontSize="1rem"
+        fontWeight="semibold"
+        color="#1a1a1a"
+      >
+        {label}
+      </Text>
+      <Text fontSize="1rem" color="gray.700">
+        {value}
+      </Text>
+    </HStack>
+  );
+}
+
+function MessageCard({ title, body }: { title: string; body: string }) {
+  return (
+    <Stack
+      bg="white"
+      rounded="md"
+      shadow="md"
+      maxW="480px"
+      w="full"
+      p={{ base: 6, md: 10 }}
+      gap={3}
+      textAlign="center"
+    >
+      <Heading size="md" color="gray.900">
+        {title}
+      </Heading>
+      <Text fontSize="sm" color="#666666">
+        {body}
+      </Text>
+    </Stack>
+  );
+}
+
+function ReportForm({
+  token,
+  displayName,
+}: {
+  token: string;
+  displayName: string;
+}) {
+  const form = useReportFoundItemForm(token);
+  // Teammate auth utils (utils/auth.ts): token drives upload/submit; the user
+  // drives the identity rows and the student-only gate the backend enforces.
+  const accessToken = getAccessToken();
+  const user = getLoggedInUser();
+  const isStudent = user?.role === 'student';
+
+  return (
+    <Stack
+      bg="white"
+      rounded="md"
+      shadow="md"
+      maxW="720px"
+      w="full"
+      p={{ base: 6, md: 10 }}
+      gap={6}
+    >
+      <Box>
+        <Heading size="lg" color="gray.900">
+          Report Found Item
+        </Heading>
+        <Text fontSize="sm" color="#666666" mt={1}>
+          Please provide as much detail as possible to help with identification.
+        </Text>
+      </Box>
+
+      {/*
+        Read-only identity rows from the design. Registrant is the logged-in
+        student. Finder has no data source yet — the report link only carries a
+        campus, and the backend records the submitter as the finder — so it
+        falls back to the logged-in user. Wire to real link data once available.
+      */}
+      <Stack gap={2}>
+        <ReadonlyRow label="Finder" value={displayName || '—'} />
+        <ReadonlyRow label="Registrant" value={displayName || '—'} />
+      </Stack>
+
+      {!accessToken && (
+        <Text fontSize="sm" color="red.600">
+          You must be logged in as a student to submit this report.
+        </Text>
+      )}
+
+      {accessToken && !isStudent && (
+        <Text fontSize="sm" color="red.600">
+          Only student accounts can submit found-item reports.
+        </Text>
+      )}
+
+      <Stack gap={5}>
+        {/* Field order follows the Figma design (node 116-2394). */}
+        <FormTextInput
+          id="itemName"
+          label="Item Name"
+          required
+          placeholder="e.g., Black Nike Backpack"
+          maxLength={100}
+          value={form.itemName}
+          error={form.errors.itemName}
+          onChange={(e) => {
+            form.setItemName(e.target.value);
+            form.clearError('itemName');
+          }}
+        />
+
+        <SelectInput
+          id="category"
+          label="Category"
+          required
+          options={CATEGORIES}
+          placeholder="Select a category"
+          value={form.category}
+          error={form.errors.category}
+          onChange={(e) => {
+            form.setCategory(e.target.value);
+            form.clearError('category');
+          }}
+        />
+
+        <FormTextInput
+          id="date"
+          label="Date"
+          required
+          type="date"
+          max={form.todayISO()}
+          value={form.date}
+          error={form.errors.date}
+          onChange={(e) => {
+            form.setDate(e.target.value);
+            form.clearError('date');
+          }}
+        />
+
+        {/* STUB — not persisted (no report column; see notes at top of file). */}
+        <FormTextInput
+          id="contactInformation"
+          label="Contact Information"
+          required
+          placeholder="Your email or phone number"
+          value={form.contactInformation}
+          error={form.errors.contactInformation}
+          onChange={(e) => {
+            form.setContactInformation(e.target.value);
+            form.clearError('contactInformation');
+          }}
+        />
+
+        <FormTextInput
+          id="location"
+          label="Location"
+          required
+          placeholder="Where was it lost/found?"
+          maxLength={100}
+          value={form.location}
+          error={form.errors.location}
+          onChange={(e) => {
+            form.setLocation(e.target.value);
+            form.clearError('location');
+          }}
+        />
+
+        {/* STUB — campus is derived from the link server-side; this is display-only. */}
+        <SelectInput
+          id="campus"
+          label="Campus"
+          required
+          options={CAMPUSES.map((c) => c.name)}
+          placeholder="Select a campus"
+          value={form.campus}
+          error={form.errors.campus}
+          onChange={(e) => {
+            form.setCampus(e.target.value);
+            form.clearError('campus');
+          }}
+        />
+
+        {/* Image + Description span full width with the label above (design). */}
+        {accessToken && (
+          <Box>
+            <Text mb={2} fontSize="1rem" fontWeight="semibold" color="#1a1a1a">
+              Image
+            </Text>
+            <ImageUploadGallery
+              accessToken={accessToken}
+              onChange={(images) => form.setImageRefs(images)}
+            />
+          </Box>
+        )}
+
+        <TextAreaInput
+          id="description"
+          label="Description"
+          required
+          stacked
+          placeholder="Describe the item — color, brand, size, distinguishing features"
+          maxLength={1000}
+          value={form.description}
+          error={form.errors.description}
+          onChange={(e) => {
+            form.setDescription(e.target.value);
+            form.clearError('description');
+          }}
+        />
+      </Stack>
+
+      {form.submitError && (
+        <HStack gap={2} color="red.600">
+          <LuCircleAlert size={16} aria-hidden />
+          <Text fontSize="sm" fontWeight="medium">
+            {form.submitError}
+          </Text>
+        </HStack>
+      )}
+
+      <HStack justify="center" gap={4} pt={2}>
+        <Button
+          variant="outline"
+          borderColor="#D9D9D9"
+          w="140px"
+          onClick={form.handleCancel}
+          disabled={form.isSubmitting}
+        >
+          Cancel
+        </Button>
+        <Button
+          colorPalette="blue"
+          w="140px"
+          loading={form.isSubmitting}
+          loadingText="Submitting..."
+          onClick={form.handleSubmit}
+        >
+          Submit
+        </Button>
+      </HStack>
+    </Stack>
+  );
+}

--- a/foundit-ui/components/FieldError.tsx
+++ b/foundit-ui/components/FieldError.tsx
@@ -1,0 +1,27 @@
+'use client';
+
+import { Box, Field, HStack } from '@chakra-ui/react';
+import { LuCircleAlert } from 'react-icons/lu';
+
+// Field error row with a leading warning icon. Always reserves one line of
+// height so toggling the error never shifts the surrounding layout. Must be
+// rendered inside a Field.Root (uses Field.ErrorText for a11y).
+export default function FieldError({ error }: { error?: string }) {
+  return (
+    <Box minH="1.375rem" mt={1}>
+      {error && (
+        <Field.ErrorText
+          fontSize="0.875rem"
+          fontWeight="normal"
+          color="#cd0000"
+          m={0}
+        >
+          <HStack gap={1} align="center">
+            <LuCircleAlert size={14} aria-hidden />
+            <span>{error}</span>
+          </HStack>
+        </Field.ErrorText>
+      )}
+    </Box>
+  );
+}

--- a/foundit-ui/components/FormTextInput.tsx
+++ b/foundit-ui/components/FormTextInput.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import React from 'react';
+import { Box, Field, HStack, Input } from '@chakra-ui/react';
+import FieldError from './FieldError';
+
+export interface FormTextInputProps extends Omit<
+  React.InputHTMLAttributes<HTMLInputElement>,
+  'id' | 'size' | 'width'
+> {
+  label: string;
+  required?: boolean;
+  hint?: string;
+  error?: string;
+  id?: string;
+}
+
+// Two-column field (label left, input right) matching the Figma design. The
+// error renders below the input in the right column. Kept separate from the
+// shared components/TextInput so other pages keep their stacked layout.
+export default function FormTextInput({
+  label,
+  required = false,
+  hint,
+  error,
+  id,
+  onBlur,
+  ...rest
+}: FormTextInputProps) {
+  const isInvalid = !!error;
+
+  return (
+    <Field.Root id={id} required={required} invalid={isInvalid} mb={0}>
+      <HStack align="flex-start" gap={4} w="full">
+        <Field.Label
+          w="180px"
+          flexShrink={0}
+          mt={2.5}
+          mb={0}
+          fontSize="1rem"
+          fontWeight="semibold"
+          lineHeight="1.6"
+          color="#1a1a1a"
+          whiteSpace="nowrap"
+        >
+          {label}
+          <Field.RequiredIndicator color="#1a1a1a" />
+        </Field.Label>
+
+        <Box flex={1}>
+          {hint && (
+            <Field.HelperText
+              fontSize="0.875rem"
+              lineHeight="1.6"
+              color="#666666"
+              mt={0}
+              mb={1}
+            >
+              {hint}
+            </Field.HelperText>
+          )}
+
+          <Input
+            h={12}
+            px={4}
+            w="full"
+            fontSize="1rem"
+            fontWeight="normal"
+            color="#1a1a1a"
+            bg="white"
+            borderWidth="1px"
+            borderRadius="md"
+            borderColor="#D9D9D9"
+            _invalid={{ borderColor: '#cd0000' }}
+            _focusVisible={{
+              outline: 'none',
+              boxShadow: '0 0 0 2px #009adb',
+              borderColor: 'inherit',
+            }}
+            onBlur={onBlur}
+            {...rest}
+          />
+
+          <FieldError error={error} />
+        </Box>
+      </HStack>
+    </Field.Root>
+  );
+}

--- a/foundit-ui/components/SelectInput.tsx
+++ b/foundit-ui/components/SelectInput.tsx
@@ -1,0 +1,103 @@
+'use client';
+
+import React from 'react';
+import { Box, Field, HStack, NativeSelect } from '@chakra-ui/react';
+import FieldError from './FieldError';
+
+export interface SelectInputProps {
+  label: string;
+  options: readonly string[];
+  required?: boolean;
+  hint?: string;
+  error?: string;
+  id?: string;
+  placeholder?: string;
+  value?: string;
+  onChange?: React.ChangeEventHandler<HTMLSelectElement>;
+  onBlur?: React.FocusEventHandler<HTMLSelectElement>;
+}
+
+// Two-column <select> field (label left, control right) matching FormTextInput.
+export default function SelectInput({
+  label,
+  options,
+  required = false,
+  hint,
+  error,
+  id,
+  placeholder = 'Select an option',
+  value,
+  onChange,
+  onBlur,
+}: SelectInputProps) {
+  const isInvalid = !!error;
+
+  return (
+    <Field.Root id={id} required={required} invalid={isInvalid} mb={0}>
+      <HStack align="flex-start" gap={4} w="full">
+        <Field.Label
+          w="180px"
+          flexShrink={0}
+          mt={2.5}
+          mb={0}
+          fontSize="1rem"
+          fontWeight="semibold"
+          lineHeight="1.6"
+          color="#1a1a1a"
+          whiteSpace="nowrap"
+        >
+          {label}
+          <Field.RequiredIndicator color="#1a1a1a" />
+        </Field.Label>
+
+        <Box flex={1}>
+          {hint && (
+            <Field.HelperText
+              fontSize="0.875rem"
+              lineHeight="1.6"
+              color="#666666"
+              mt={0}
+              mb={1}
+            >
+              {hint}
+            </Field.HelperText>
+          )}
+
+          <NativeSelect.Root w="full">
+            <NativeSelect.Field
+              value={value}
+              onChange={onChange}
+              onBlur={onBlur}
+              h={12}
+              px={4}
+              fontSize="1rem"
+              color={value ? '#1a1a1a' : '#9ca3af'}
+              bg="white"
+              borderWidth="1px"
+              borderRadius="md"
+              borderColor="#D9D9D9"
+              _invalid={{ borderColor: '#cd0000' }}
+              _focusVisible={{
+                outline: 'none',
+                boxShadow: '0 0 0 2px #009adb',
+                borderColor: 'inherit',
+              }}
+            >
+              <option value="" disabled>
+                {placeholder}
+              </option>
+              {options.map((option) => (
+                <option key={option} value={option}>
+                  {option}
+                </option>
+              ))}
+            </NativeSelect.Field>
+            <NativeSelect.Indicator />
+          </NativeSelect.Root>
+
+          <FieldError error={error} />
+        </Box>
+      </HStack>
+    </Field.Root>
+  );
+}

--- a/foundit-ui/components/TextAreaInput.tsx
+++ b/foundit-ui/components/TextAreaInput.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import React from 'react';
+import { Box, Field, HStack, Textarea } from '@chakra-ui/react';
+import FieldError from './FieldError';
+
+export interface TextAreaInputProps extends Omit<
+  React.TextareaHTMLAttributes<HTMLTextAreaElement>,
+  'id'
+> {
+  label: string;
+  required?: boolean;
+  hint?: string;
+  error?: string;
+  id?: string;
+  // When true, the label sits ABOVE the field (full width) instead of in the
+  // left column. Used for Description to match the design.
+  stacked?: boolean;
+}
+
+export default function TextAreaInput({
+  label,
+  required = false,
+  hint,
+  error,
+  id,
+  stacked = false,
+  onBlur,
+  ...rest
+}: TextAreaInputProps) {
+  const isInvalid = !!error;
+
+  const control = (
+    <Textarea
+      minH="120px"
+      px={4}
+      py={3}
+      w="full"
+      fontSize="1rem"
+      fontWeight="normal"
+      color="#1a1a1a"
+      bg="white"
+      borderWidth="1px"
+      borderRadius="md"
+      borderColor="#D9D9D9"
+      _invalid={{ borderColor: '#cd0000' }}
+      _focusVisible={{
+        outline: 'none',
+        boxShadow: '0 0 0 2px #009adb',
+        borderColor: 'inherit',
+      }}
+      onBlur={onBlur}
+      {...rest}
+    />
+  );
+
+  const hintEl = hint ? (
+    <Field.HelperText
+      fontSize="0.875rem"
+      lineHeight="1.6"
+      color="#666666"
+      mt={0}
+      mb={1}
+    >
+      {hint}
+    </Field.HelperText>
+  ) : null;
+
+  const errorEl = <FieldError error={error} />;
+
+  if (stacked) {
+    return (
+      <Field.Root id={id} required={required} invalid={isInvalid} mb={0}>
+        <Field.Label
+          mb={1}
+          fontSize="1rem"
+          fontWeight="semibold"
+          lineHeight="1.6"
+          color="#1a1a1a"
+        >
+          {label}
+          <Field.RequiredIndicator color="#1a1a1a" />
+        </Field.Label>
+        {hintEl}
+        {control}
+        {errorEl}
+      </Field.Root>
+    );
+  }
+
+  return (
+    <Field.Root id={id} required={required} invalid={isInvalid} mb={0}>
+      <HStack align="flex-start" gap={4} w="full">
+        <Field.Label
+          w="180px"
+          flexShrink={0}
+          mt={2.5}
+          mb={0}
+          fontSize="1rem"
+          fontWeight="semibold"
+          lineHeight="1.6"
+          color="#1a1a1a"
+          whiteSpace="nowrap"
+        >
+          {label}
+          <Field.RequiredIndicator color="#1a1a1a" />
+        </Field.Label>
+
+        <Box flex={1}>
+          {hintEl}
+          {control}
+          {errorEl}
+        </Box>
+      </HStack>
+    </Field.Root>
+  );
+}

--- a/foundit-ui/constants/categories.ts
+++ b/foundit-ui/constants/categories.ts
@@ -1,0 +1,17 @@
+/**
+ * Category options for the Report Found Item form.
+ * The backend column (`Item.category` / `FoundItemReport.category`) is free-text
+ * varchar(50), so these values are a product choice — keep each ≤ 50 chars.
+ */
+export const CATEGORIES = [
+  'Electronics',
+  'Clothing',
+  'Bags & Luggage',
+  'Books & Stationery',
+  'IDs & Cards',
+  'Keys',
+  'Wallets & Purses',
+  'Jewelry & Accessories',
+  'Water Bottles',
+  'Other',
+] as const;

--- a/foundit-ui/docs/report-found-form.md
+++ b/foundit-ui/docs/report-found-form.md
@@ -1,0 +1,168 @@
+# Report Found Item — Flow & Status
+
+> Status doc for the **Report Found Item** feature. Reflects the implementation as
+> of 2026-06-15. Safe to commit/share (unlike the local-only `plan.md` /
+> `implementation.md`).
+
+## 1. What it is
+
+A token-keyed page where a logged-in **student** submits a found-item report.
+Security generates a single-use report link (intended as a QR code); the student
+opens that link, the page validates the token, and the student fills + submits the
+form. The page is **not** reachable from the navbar — the token in the URL is the
+only entry point.
+
+Route: `app/report-found/[token]/page.tsx` → URL `/report-found/<token>`.
+
+## 2. End-to-end flow
+
+```
+[security] generate report link  ──►  (NOT BUILT — see Gaps #5; create the row in DB for now)
+        │
+        ▼  hand link/QR to finder
+[student] open /report-found/<token>
+        │
+        ▼  GET /api/report-links/:token/validate          (public, rate-limited 30/15min)
+        │     → { valid, reason, campusId, expiresAt?, usedAt? }
+        │       reason ∈ available | not_found | used | expired
+        ├─ reason !== available ──► message card (used / expired / invalid)
+        └─ reason === available  ──► render the form
+        │
+        ▼  (optional) pick images
+        │     ImageUploadGallery → POST /api/uploads/presigned-url (Bearer)
+        │     → browser PUTs the file straight to Cloudflare R2
+        │
+        ▼  Submit
+        │     POST /api/report-links/:token/submit          (Bearer + student role, 10/15min)
+        │     body { itemDescription, category, locationFound, dateFound }
+        │     → 201: creates FoundItemReport (finderId = caller), consumes the link
+        │     → 4xx mapped to a friendly message (see status map)
+        └─ on success → router.push(ROLE_HOME.student)  (/student/dashboard)
+```
+
+Backend rules enforced on submit:
+
+- Caller must be authenticated with the **student** role (else 401/403).
+- The caller's `campusId` must equal the **link's** campus (else 403).
+- Link is **single-use** + expiring; a second submit races to **409**.
+- The submitter is recorded as the **finder** (`finderId = req.user.user_id`).
+
+## 3. Files
+
+### New (this feature)
+
+| File                                | Responsibility                                                                                                                                                           |
+| ----------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `app/report-found/[token]/page.tsx` | Route. Validates the token, branches on link state (loading / error / used / expired / not_found / form), renders the form + shell. Has a `// NOTES FOR THE TEAM` block. |
+| `hooks/useReportFoundItemForm.ts`   | Form state, client validation (mirrors the backend schema), submit (real POST) + cancel, status→message mapping.                                                         |
+| `components/FormTextInput.tsx`      | 2-column text input (label left, input right), error below.                                                                                                              |
+| `components/SelectInput.tsx`        | 2-column `NativeSelect` wrapper.                                                                                                                                         |
+| `components/TextAreaInput.tsx`      | 2-column textarea; `stacked` prop renders label-above (used by Description).                                                                                             |
+| `components/FieldError.tsx`         | Error row with warning icon (`LuCircleAlert`); reserves one line of height to prevent layout shift.                                                                      |
+| `constants/categories.ts`           | `CATEGORIES` options for the Category select.                                                                                                                            |
+
+### Reused (teammates' code — not modified)
+
+| File                                                                                        | Used for                                                             |
+| ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| `components/uploadImage.tsx` (`ImageUploadGallery`)                                         | Image upload UI (uploads to R2 on select).                           |
+| `hooks/useImageUploadGallery.ts`, `utils/handleImageUpload.ts`, `utils/imageCompression.ts` | Upload pipeline (presign → PUT) + compression.                       |
+| `utils/auth.ts`                                                                             | `getAccessToken` (Bearer), `getLoggedInUser` (identity + role gate). |
+| `hooks/useLoggedInDisplayName.ts`                                                           | Display name for Navbar + Finder/Registrant rows.                    |
+| `components/Navbar.tsx`, `components/Footer.tsx`                                            | Page shell (student variant).                                        |
+| `constants/campuses.ts` (`CAMPUSES`)                                                        | Campus select options (stub).                                        |
+
+### Backend (consumed, owned by backend team)
+
+| File                                    | What                                            |
+| --------------------------------------- | ----------------------------------------------- |
+| `backend/src/routes/reportLinks.ts`     | `GET /:token/validate`, `POST /:token/submit`.  |
+| `backend/src/validators/reportLinks.ts` | `submitFoundItemReportSchema`.                  |
+| `backend/src/routes/uploads.ts`         | `POST /api/uploads/presigned-url` (R2 presign). |
+| `backend/src/lib/r2.ts`                 | R2 / S3 client.                                 |
+| `backend/prisma/schema.prisma`          | `FoundItemReport`, `ReportLink` models.         |
+
+## 4. Field mapping (form → backend)
+
+`submitFoundItemReportSchema` accepts exactly: `itemDescription` (≤1000),
+`category` (≤50), `locationFound` (≤100), `dateFound` (YYYY-MM-DD, not future).
+`timeFound` / `additionalNotes` are valid optional columns but **not exposed**
+(the design omits them).
+
+| Form field                      | Required | Sent as                   | Notes                                                                                                                                |
+| ------------------------------- | -------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Item Name                       | ✅       | part of `itemDescription` | No DB column → folded into the description's first line (no data lost).                                                              |
+| Category                        | ✅       | `category`                | Free-text column; dropdown is a product choice (`constants/categories.ts`).                                                          |
+| Date                            | ✅       | `dateFound`               | Native date input, `max=today`, not-future validated.                                                                                |
+| Contact Information             | ✅       | — (**STUB**, not sent)    | No report column (only `User.phone`, a profile field).                                                                               |
+| Location                        | ✅       | `locationFound`           |                                                                                                                                      |
+| Campus                          | ✅       | — (**STUB**, not sent)    | `campusId` exists on `report_link`/`user`/`item` and is **derived + validated from the link** server-side; the picker is decorative. |
+| Image                           | optional | — (not linked)            | Uploads to R2 but the submit schema has no image field → orphaned.                                                                   |
+| Description                     | ✅       | `itemDescription`         | Combined `Item Name + Description` validated against the 1000 cap.                                                                   |
+| Finder / Registrant (read-only) | —        | —                         | Both fall back to the logged-in user; the link carries no separate identity.                                                         |
+
+## 5. Current status
+
+**Working**
+
+- Token validation + all link states (loading / available / used / expired / not_found / network error).
+- Full client validation matching the backend; required asterisks (black); errors render below each field with a warning icon and reserved space (no layout shift).
+- 2-column layout (labels aligned at 180px); Image + Description are label-above full width.
+- Real submit to `POST /api/report-links/:token/submit` with status→message mapping and success redirect.
+- Student-role gate + "must be logged in" notice using `getLoggedInUser`.
+
+**Stubbed (intentional, kept for now)**
+
+- **Contact Information** and **Campus** — rendered + validated for design parity but **not sent** (no/derived backend column). Documented in code.
+- **Finder / Registrant** rows — display the logged-in user (no real per-role source yet).
+
+## 6. Known gaps / risks
+
+1. **Images never linked to the report** — submit schema has no image field, so uploaded R2 objects are orphaned. Needs backend to accept image refs (+ create `ItemImage`).
+2. **No R2 cleanup** + the gallery's remove doesn't delete from R2 → orphans accumulate.
+3. **Immediate upload is fragile** — access token lives **15 min** with no refresh; uploads 401 if the user lingers.
+4. **R2 bucket has no CORS policy** for `http://localhost:3000` → browser PUT is blocked locally until a CORS policy is added.
+5. **No security-side link generation** — no `POST /api/report-links` endpoint or UI. Links must be created in the DB for now.
+6. **Campus name unresolvable** — `validate().campusId` is a UUID, but `constants/campuses.ts` uses slug ids; needs a campuses lookup to display the link's actual campus.
+7. **Login has no return-URL** — "scan QR while logged out → login → back to form" isn't wired; the page just shows a notice.
+
+## 7. How to test
+
+**Setup**
+
+```bash
+# backend (Postgres + .env with DB, JWT, R2 vars)
+cd backend && pnpm install && npx prisma migrate dev && npx prisma db seed && pnpm dev
+# frontend (.env already has NEXT_PUBLIC_API_URL=http://localhost:3001)
+cd foundit-ui && pnpm install && pnpm dev
+```
+
+**Run**
+
+1. Log in as `alice@myseneca.ca` / `Test1234!` (Newnham student — matches the seeded link).
+2. Open `http://localhost:3000/report-found/dev-sample-token-abc123`.
+
+**Matrix**
+| Case | How | Expect |
+|---|---|---|
+| Happy path | fill required fields, Submit | 201 → redirect to dashboard; new `found_item_report` row |
+| Validation | submit empty | each required field shows "{Field} is a required field" + icon, no layout shift |
+| Future date | pick a future date | "Date cannot be in the future" |
+| Used / expired / invalid | reuse a consumed token / bad token | matching message card |
+| Campus 403 | log in as `bob@myseneca.ca` (Seneca@York) | "cannot submit reports for this campus" |
+| Not logged in | clear localStorage | "must be logged in" notice + 401 on submit |
+| Wrong role | log in as security (`carol@myseneca.ca`) | "Only student accounts can submit…" |
+
+**Caveats**
+
+- Image upload needs (a) an R2 CORS policy for `localhost:3000` and (b) a fresh (non-expired) token. The rest of the form works without images.
+- Re-testing the happy path needs the link reset: `cd backend && npx prisma studio` → `report_link` → set `is_used`=false, `used_at`=null — or create a new `report_link` row and use its token.
+
+Seed reference: users `alice`/`bob` (students), `carol` (security), password `Test1234!`;
+report link token `dev-sample-token-abc123` (Newnham, 7-day expiry).
+
+## 8. Future work
+
+- Backend: accept image refs on submit; add `POST /api/report-links` + a security-side generate UI; consider a contact column or drop the field; campuses lookup endpoint.
+- Frontend: when backend supports it, wire `imageRefs` into the submit body (one line in the hook); resolve campus name; align stubs to reality (Campus read-only, drop Contact/Registrant) — see the AskUserQuestion decision deferred with "have the stubs for now".
+- Infra: R2 CORS policy for dev origins; R2 lifecycle rule to reap orphaned `reports/` objects.

--- a/foundit-ui/hooks/useReportFoundItemForm.ts
+++ b/foundit-ui/hooks/useReportFoundItemForm.ts
@@ -1,0 +1,207 @@
+'use client';
+
+import { useState } from 'react';
+import { useRouter } from 'next/navigation';
+import { getAccessToken } from '@/utils/auth';
+import { ROLE_HOME } from '@/utils/routes';
+import { CAMPUSES } from '@/constants/campuses';
+
+const API_BASE = process.env.NEXT_PUBLIC_API_URL ?? '';
+
+// Backend itemDescription cap (submitFoundItemReportSchema).
+const DESCRIPTION_MAX = 1000;
+
+// Default for the Campus stub (matches the design's "Newnham" default).
+const DEFAULT_CAMPUS = CAMPUSES[0].name;
+
+// Matches the Figma error copy: "{Field} is a required field".
+function requiredMsg(label: string): string {
+  return `${label} is a required field`;
+}
+
+// Local YYYY-MM-DD, used both for the date input `max` and the not-in-future check.
+function todayISO(): string {
+  const now = new Date();
+  const offset = now.getTimezoneOffset() * 60_000;
+  return new Date(now.getTime() - offset).toISOString().slice(0, 10);
+}
+
+interface ImageRef {
+  imageUrl: string;
+  fileType: string;
+}
+
+export function useReportFoundItemForm(token: string) {
+  const router = useRouter();
+
+  const [itemName, setItemName] = useState('');
+  const [category, setCategory] = useState('');
+  const [date, setDate] = useState('');
+  const [location, setLocation] = useState('');
+  const [description, setDescription] = useState('');
+  // ── STUB FIELDS ──────────────────────────────────────────────────────────
+  // Contact Information and Campus are shown for design parity but are NOT
+  // persisted: the backend (submitFoundItemReportSchema) has no contact column,
+  // and campus is fixed server-side by the report link. They are validated
+  // client-side (the design marks them required) but excluded from the submit
+  // body. Remove the stub note + wire into the payload once the backend grows
+  // the columns. See plan.md.
+  const [contactInformation, setContactInformation] = useState('');
+  const [campus, setCampus] = useState(DEFAULT_CAMPUS);
+  // Fed by the image gallery (uploaded to R2 on select). Intentionally NOT sent
+  // in the submit body — the report-link submit schema has no image field yet
+  // (see plan.md 🟠). Wiring is one line once the backend accepts image refs.
+  const [imageRefs, setImageRefs] = useState<ImageRef[]>([]);
+
+  const [errors, setErrors] = useState<Record<string, string>>({});
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // The backend has no item-name column, so Item Name is folded into
+  // itemDescription as the first line (no data lost). See plan.md.
+  function buildItemDescription(): string {
+    return [itemName.trim(), description.trim()].filter(Boolean).join('\n\n');
+  }
+
+  function clearError(field: string) {
+    setErrors((prev) => {
+      if (!prev[field]) return prev;
+      const next = { ...prev };
+      delete next[field];
+      return next;
+    });
+  }
+
+  // Mirrors submitFoundItemReportSchema so the client fails fast before the POST.
+  function validate(): boolean {
+    const next: Record<string, string> = {};
+
+    if (!itemName.trim()) {
+      next.itemName = requiredMsg('Item Name');
+    } else if (itemName.trim().length > 100) {
+      next.itemName = 'Item Name must be 100 characters or fewer';
+    }
+
+    if (!category.trim()) {
+      next.category = requiredMsg('Category');
+    }
+
+    if (!date.trim()) {
+      next.date = requiredMsg('Date');
+    } else if (date > todayISO()) {
+      next.date = 'Date cannot be in the future';
+    }
+
+    if (!location.trim()) {
+      next.location = requiredMsg('Location');
+    } else if (location.trim().length > 100) {
+      next.location = 'Location must be 100 characters or fewer';
+    }
+
+    // Stub fields — validated for design parity, not sent to the backend.
+    if (!contactInformation.trim()) {
+      next.contactInformation = requiredMsg('Contact Information');
+    }
+
+    if (!campus.trim()) {
+      next.campus = requiredMsg('Campus');
+    }
+
+    if (!description.trim()) {
+      next.description = requiredMsg('Description');
+    } else if (buildItemDescription().length > DESCRIPTION_MAX) {
+      next.description = `Item Name and Description together must be ${DESCRIPTION_MAX} characters or fewer`;
+    }
+
+    setErrors(next);
+    return Object.keys(next).length === 0;
+  }
+
+  function messageForStatus(status: number): string {
+    switch (status) {
+      case 401:
+        return 'Please log in as a student to submit this report.';
+      case 403:
+        return 'Your account cannot submit reports for this campus.';
+      case 404:
+        return 'This report link no longer exists.';
+      case 409:
+        return 'This report link has already been used or has expired.';
+      case 429:
+        return 'Too many attempts. Please wait a moment and try again.';
+      default:
+        return 'Something went wrong submitting your report. Please try again.';
+    }
+  }
+
+  async function handleSubmit() {
+    setSubmitError(null);
+    if (!validate()) return;
+
+    const accessToken = getAccessToken();
+    if (!accessToken) {
+      setSubmitError(messageForStatus(401));
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      const res = await fetch(`${API_BASE}/api/report-links/${token}/submit`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${accessToken}`,
+        },
+        body: JSON.stringify({
+          itemDescription: buildItemDescription(),
+          category: category.trim(),
+          locationFound: location.trim(),
+          dateFound: date,
+          // NOTE: contactInformation + campus are intentionally omitted — they
+          // are stub fields with no backend column (see state declaration).
+        }),
+      });
+
+      if (res.ok) {
+        router.push(ROLE_HOME.student);
+        return;
+      }
+
+      setSubmitError(messageForStatus(res.status));
+    } catch {
+      setSubmitError(messageForStatus(0));
+    } finally {
+      setIsSubmitting(false);
+    }
+  }
+
+  function handleCancel() {
+    router.back();
+  }
+
+  return {
+    itemName,
+    setItemName,
+    category,
+    setCategory,
+    date,
+    setDate,
+    location,
+    setLocation,
+    description,
+    setDescription,
+    contactInformation,
+    setContactInformation,
+    campus,
+    setCampus,
+    imageRefs,
+    setImageRefs,
+    errors,
+    clearError,
+    isSubmitting,
+    submitError,
+    todayISO,
+    handleSubmit,
+    handleCancel,
+  };
+}


### PR DESCRIPTION
## Summary
Adds the student-facing **Report Found Item** page, reached via a security-issued report-link token (`/report-found/<token>`). The page validates the token, renders the form, and submits a found-item report.

## What's included
- **Route** `app/report-found/[token]/page.tsx`: validates the token (`GET /api/report-links/:token/validate`) and branches on link state — loading / available / used / expired / not_found / error.
- **Submit** `POST /api/report-links/:token/submit` (Bearer + student role) with friendly status→message mapping; on success redirects to the student dashboard.
- **Fields** in design order: Item Name, Category, Date, Contact Information*, Location, Campus*, Image, Description. Client validation mirrors `submitFoundItemReportSchema`. Item Name is folded into `itemDescription` (no backend column).
- **New field components** (`FormTextInput` / `SelectInput` / `TextAreaInput` / `FieldError`): 2-column layout, black required asterisks, warning-icon errors with reserved space (no layout shift).
- **Reuses teammate code** unchanged: `ImageUploadGallery`, `utils/auth` (`getAccessToken`/`getLoggedInUser`), `constants/campuses`.
- **Docs**: `foundit-ui/docs/report-found-form.md` — full flow, files, field mapping, status, gaps, and test steps.

## Stubs / not yet wired (documented in code + docs)
- `*` **Contact Information** and **Campus** are stub fields — rendered for design parity but **not sent** (no/derived backend column).
- **Image** uploads to R2 but isn't linked to the report (submit schema has no image field).
- **Finder / Registrant** rows fall back to the logged-in user (link carries no separate identity).

## Known gaps (see docs)
No security-side link-generation endpoint/UI yet (create the `report_link` row in DB to test); R2 needs a CORS policy for `localhost:3000` for uploads; access token is 15 min with no refresh.

## Testing
Log in as `alice@myseneca.ca` / `Test1234!` (Newnham student), open `/report-found/dev-sample-token-abc123`. Full matrix (validation, used/expired, 403 campus mismatch, wrong role) in the docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added "Report Found Item" feature allowing users to submit reports for found items through a secure token-based form. The form collects item details (category, date, location, description) with validation, supports optional image uploads for authenticated users, and includes campus information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->