### PR TITLE
feat(security): item detail page with frontend edit mode

### DIFF
--- a/foundit-ui/app/security/items/[itemId]/page.tsx
+++ b/foundit-ui/app/security/items/[itemId]/page.tsx
@@ -1,0 +1,448 @@
+'use client';
+
+import { useEffect, useState, type ReactNode } from 'react';
+import { useParams, useRouter } from 'next/navigation';
+import {
+  Box,
+  Button,
+  Flex,
+  Heading,
+  Image,
+  Input,
+  NativeSelect,
+  Spinner,
+  Stack,
+  Text,
+  Textarea,
+} from '@chakra-ui/react';
+import { fetchSecurityItem } from '@/lib/api/items';
+import { CATEGORIES } from '@/constants/categories';
+import type { SecurityItemDetail } from '@/types/items';
+
+const PLACEHOLDER = '—';
+
+function formatDate(value: string | null): string {
+  if (!value) return PLACEHOLDER;
+  return new Date(value).toLocaleDateString('en-CA');
+}
+
+// Date input expects YYYY-MM-DD; reuse the en-CA locale (already YYYY-MM-DD).
+function toDateInputValue(value: string | null): string {
+  if (!value) return '';
+  const d = new Date(value);
+  return Number.isNaN(d.getTime()) ? '' : d.toLocaleDateString('en-CA');
+}
+
+interface EditForm {
+  title: string;
+  category: string;
+  dateFound: string;
+  locationFound: string;
+  description: string;
+}
+
+const editInputStyles = {
+  size: 'sm' as const,
+  borderColor: '#D9D9D9',
+  borderRadius: 'md',
+  _focusVisible: {
+    outline: 'none',
+    boxShadow: '0 0 0 2px #009adb',
+    borderColor: 'inherit',
+  },
+};
+
+function DetailRow({
+  label,
+  value,
+  valueColor = '#999',
+  valueFontSize = '16px',
+  valueMaxW,
+  input,
+}: {
+  label: string;
+  value: string;
+  valueColor?: string;
+  valueFontSize?: string;
+  valueMaxW?: string;
+  // When provided (edit mode), the control replaces the read-only value.
+  input?: ReactNode;
+}) {
+  return (
+    <Flex align="flex-start">
+      <Text
+        flexShrink={0}
+        w="145px"
+        fontSize="14px"
+        fontWeight="medium"
+        lineHeight="20px"
+        color="#666"
+        mt={input ? 1 : 0}
+      >
+        {label}
+      </Text>
+      {input ? (
+        <Box flex={1} maxW={valueMaxW}>
+          {input}
+        </Box>
+      ) : (
+        <Text
+          fontSize={valueFontSize}
+          lineHeight="24px"
+          color={valueColor}
+          maxW={valueMaxW}
+        >
+          {value}
+        </Text>
+      )}
+    </Flex>
+  );
+}
+
+export default function SecurityItemDetailPage() {
+  const params = useParams<{ itemId: string }>();
+  const router = useRouter();
+  const itemId = params?.itemId;
+
+  const [item, setItem] = useState<SecurityItemDetail | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState('');
+  const [editing, setEditing] = useState(false);
+  const [form, setForm] = useState<EditForm | null>(null);
+
+  useEffect(() => {
+    if (!itemId) return;
+
+    let active = true;
+
+    async function loadItem() {
+      setLoading(true);
+      setError('');
+
+      try {
+        const data = await fetchSecurityItem(itemId);
+        if (active) setItem(data);
+      } catch (err) {
+        if (!active) return;
+        setError(
+          err instanceof Error ? err.message : 'Failed to load item details.'
+        );
+        setItem(null);
+      } finally {
+        if (active) setLoading(false);
+      }
+    }
+
+    loadItem();
+    return () => {
+      active = false;
+    };
+  }, [itemId]);
+
+  function handleCancel() {
+    router.push('/security/items');
+  }
+
+  function handleStartEdit() {
+    if (!item) return;
+    setForm({
+      title: item.title,
+      category: item.category,
+      dateFound: toDateInputValue(item.dateFound),
+      locationFound: item.locationFound ?? '',
+      description: item.descriptionPublic ?? item.descriptionInternal ?? '',
+    });
+    setEditing(true);
+  }
+
+  function handleCancelEdit() {
+    setEditing(false);
+    setForm(null);
+  }
+
+  function handleFormChange<K extends keyof EditForm>(
+    key: K,
+    value: EditForm[K]
+  ) {
+    setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
+  }
+
+  // TODO(backend): no PATCH /api/items/:itemId yet — Save only updates local
+  // state so the edit is visible for this session; it does NOT persist.
+  function handleSave() {
+    if (!item || !form) return;
+    setItem({
+      ...item,
+      title: form.title,
+      category: form.category,
+      dateFound: form.dateFound,
+      locationFound: form.locationFound.trim() || null,
+      descriptionPublic: form.description.trim() || null,
+    });
+    setEditing(false);
+    setForm(null);
+  }
+
+  if (loading) {
+    return (
+      <Flex justify="center" py={16}>
+        <Spinner size="lg" color="blue.500" />
+      </Flex>
+    );
+  }
+
+  if (error || !item) {
+    return (
+      <Stack gap={4} py={12} align="center">
+        <Text color="red.500" fontSize="md">
+          {error || 'Item not found.'}
+        </Text>
+        <Button variant="outline" onClick={handleCancel}>
+          Back to items
+        </Button>
+      </Stack>
+    );
+  }
+
+  const registrantName =
+    `${item.registeredBy.firstName} ${item.registeredBy.lastName}`.trim() ||
+    PLACEHOLDER;
+  const pickedUp = item.status === 'claimed' ? 'Yes' : 'No';
+  const description =
+    item.descriptionPublic ?? item.descriptionInternal ?? PLACEHOLDER;
+  const photoUrl = item.images[0]?.imageUrl ?? null;
+
+  // ─── NOTES FOR THE TEAM ────────────────────────────────────────────────────
+  // Finder name + Finder Contact have no real data source yet (kept UI-only):
+  //   • GET /api/items/:itemId does not return them. The path would be
+  //     Item -> foundItemReport -> finder (User), exposed via
+  //     securityItemDetailSelect, toSecurityItemDetailDto, and SecurityItemDetail.
+  //   • Caveat: the report link carries no finder identity — the backend records
+  //     the SUBMITTER as the finder (backend/src/routes/reportLinks.ts:326,
+  //     finderId: req.user!.user_id), so "Finder" would just equal the
+  //     registrant/submitter. There is also no contact column on
+  //     found_item_report (closest is user.phone), so "Finder Contact" has no
+  //     true source. Decide the real source before wiring these up.
+  //   • Same gap is documented on the other side in
+  //     app/report-found/[token]/page.tsx ("NOTES FOR THE TEAM").
+  // ───────────────────────────────────────────────────────────────────────────
+  const finderName = PLACEHOLDER;
+  const finderContact = PLACEHOLDER;
+
+  return (
+    <Box
+      bg="white"
+      borderWidth="1px"
+      borderColor="#e5e7eb"
+      borderRadius="4px"
+      maxW="941px"
+      mx="auto"
+      pt="48px"
+      px="42px"
+      pb="44px"
+    >
+      {/* Header: title + verify note + Release */}
+      <Flex
+        justify="space-between"
+        align={{ base: 'flex-start', md: 'center' }}
+        direction={{ base: 'column', md: 'row' }}
+        gap={4}
+      >
+        <Heading
+          as="h1"
+          fontSize="30px"
+          fontWeight="bold"
+          lineHeight="28px"
+          color="#1a1a1a"
+        >
+          Item Details
+        </Heading>
+        <Flex align="center" gap="20px" wrap="wrap">
+          <Text fontSize="16px" color="#999">
+            *Verify student ID before releasing item.
+          </Text>
+          {/* TODO(backend): no release endpoint yet — placeholder button. */}
+          <Button
+            w="137px"
+            h="42px"
+            bg="red.500"
+            color="white"
+            fontSize="16px"
+            fontWeight="medium"
+            borderRadius="4px"
+            disabled={editing}
+          >
+            Release
+          </Button>
+        </Flex>
+      </Flex>
+
+      {/* Body: detail fields beside the photo */}
+      <Flex
+        direction={{ base: 'column', lg: 'row' }}
+        justify="space-between"
+        align="flex-start"
+        gap={{ base: '40px', lg: '24px' }}
+        mt="40px"
+      >
+        <Stack
+          gap={editing ? '24px' : '48px'}
+          mt={{ base: 0, lg: '60px' }}
+          flex={1}
+          minW={0}
+        >
+          <DetailRow
+            label="Item Name"
+            value={item.title}
+            input={
+              editing && form ? (
+                <Input
+                  {...editInputStyles}
+                  value={form.title}
+                  onChange={(e) => handleFormChange('title', e.target.value)}
+                />
+              ) : undefined
+            }
+          />
+          <DetailRow
+            label="Category"
+            value={item.category}
+            input={
+              editing && form ? (
+                <NativeSelect.Root size="sm">
+                  <NativeSelect.Field
+                    value={form.category}
+                    borderColor="#D9D9D9"
+                    onChange={(e) =>
+                      handleFormChange('category', e.target.value)
+                    }
+                  >
+                    {CATEGORIES.map((c) => (
+                      <option key={c} value={c}>
+                        {c}
+                      </option>
+                    ))}
+                  </NativeSelect.Field>
+                  <NativeSelect.Indicator />
+                </NativeSelect.Root>
+              ) : undefined
+            }
+          />
+          <DetailRow
+            label="Date"
+            value={formatDate(item.dateFound)}
+            valueColor="#666"
+            valueFontSize="14px"
+            input={
+              editing && form ? (
+                <Input
+                  {...editInputStyles}
+                  type="date"
+                  value={form.dateFound}
+                  onChange={(e) =>
+                    handleFormChange('dateFound', e.target.value)
+                  }
+                />
+              ) : undefined
+            }
+          />
+          <DetailRow label="Finder Contact" value={finderContact} />
+          <DetailRow
+            label="Location"
+            value={item.locationFound ?? PLACEHOLDER}
+            input={
+              editing && form ? (
+                <Input
+                  {...editInputStyles}
+                  value={form.locationFound}
+                  onChange={(e) =>
+                    handleFormChange('locationFound', e.target.value)
+                  }
+                />
+              ) : undefined
+            }
+          />
+          <DetailRow label="Campus" value={item.campusName} />
+        </Stack>
+
+        <Stack gap="20px" flexShrink={0}>
+          <Stack gap="4px" fontSize="16px" fontWeight="medium" color="#666">
+            <Text lineHeight="24px">Finder: {finderName}</Text>
+            <Text lineHeight="24px">Registrant: {registrantName}</Text>
+          </Stack>
+          <Box
+            w="329px"
+            maxW="full"
+            h="366px"
+            borderRadius="8px"
+            overflow="hidden"
+            bg="gray.200"
+          >
+            {photoUrl ? (
+              <Image
+                src={photoUrl}
+                alt={item.title}
+                w="full"
+                h="full"
+                objectFit="contain"
+              />
+            ) : null}
+          </Box>
+        </Stack>
+      </Flex>
+
+      {/* Full-width rows below the photo */}
+      <Stack gap="48px" mt="40px">
+        <DetailRow
+          label="Description"
+          value={description}
+          valueMaxW="609px"
+          input={
+            editing && form ? (
+              <Textarea
+                {...editInputStyles}
+                rows={3}
+                value={form.description}
+                onChange={(e) =>
+                  handleFormChange('description', e.target.value)
+                }
+              />
+            ) : undefined
+          }
+        />
+        <DetailRow label="Is item picked up?" value={pickedUp} />
+      </Stack>
+
+      {/* Actions */}
+      <Flex justify="center" gap="26px" mt="64px">
+        <Button
+          variant="outline"
+          w="155px"
+          h="42px"
+          borderColor="#ddd"
+          color="#666"
+          fontSize="16px"
+          fontWeight="medium"
+          borderRadius="4px"
+          onClick={editing ? handleCancelEdit : handleCancel}
+        >
+          Cancel
+        </Button>
+        {/* TODO(backend): no PATCH /api/items/:itemId yet — Save updates local
+            state only (no persistence). See handleSave. */}
+        <Button
+          w="155px"
+          h="42px"
+          bg="#3b82f6"
+          color="white"
+          fontSize="16px"
+          fontWeight="medium"
+          borderRadius="4px"
+          onClick={editing ? handleSave : handleStartEdit}
+        >
+          {editing ? 'Save' : 'Edit'}
+        </Button>
+      </Flex>
+    </Box>
+  );
+}

--- a/foundit-ui/docs/security-item-detail.md
+++ b/foundit-ui/docs/security-item-detail.md
@@ -1,0 +1,179 @@
+# Security — Item Detail — Flow & Status
+
+> Status doc for the **Security Item Detail** page. Reflects the implementation as
+> of 2026-06-15. Safe to commit/share (unlike the local-only `plan.md` /
+> `implementation.md`).
+
+## 1. What it is
+
+A read-only detail view for a single found item, used by **security/admin** staff
+to look up an item and (eventually) release or edit it. Opened by clicking a row
+on the security items list.
+
+Route: `app/security/items/[itemId]/page.tsx` → URL `/security/items/<itemId>`.
+
+Access is **role-gated server-side** — the backend requires a `security` or
+`admin` role (see flow). The page itself does no client-side role check; it just
+sends the Bearer token via `authFetch`.
+
+## 2. End-to-end flow
+
+```
+[security] open /security/items/<itemId>   (from the items list)
+        │
+        ▼  useParams() → itemId ; useEffect fires on mount / itemId change
+        │     setLoading(true) → render <Spinner>
+        │
+        ▼  fetchSecurityItem(itemId)
+        │     authFetch GET /api/items/:itemId   (Bearer; auto-refresh on TOKEN_EXPIRED)
+        │       backend: authenticate + requireRole('security','admin')
+        │       → 200 SecurityItemDetail
+        │       → 404 { code: ITEM_NOT_FOUND }   → parseApiError → error message
+        │       → 400 VALIDATION_ERROR (bad itemId param)
+        │       → 401 → client tries refresh; on failure signOut() + throw
+        │
+        ├─ error || !item ──► error card: message + "Back to items" button
+        └─ success         ──► render detail (fields + photo + action buttons)
+        │
+        ▼  Cancel  → router.push('/security/items')
+           Release → ⚠ no handler / no endpoint (placeholder; disabled while editing)
+           Edit    → toggles inline EDIT MODE (fields → inputs)
+                       Save   → updates LOCAL state only (no endpoint — see Gaps #4)
+                       Cancel → discards edits, back to read mode
+```
+
+The effect uses an `active` flag in cleanup so a stale response from a previous
+`itemId` can't overwrite state (race guard).
+
+## 3. Files
+
+### This feature
+
+| File                                   | Responsibility                                                                                                                                                               |
+| -------------------------------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `app/security/items/[itemId]/page.tsx` | Route. Fetches the item, branches loading / error / loaded, derives display values, renders fields + photo + actions. Has a `// NOTES FOR THE TEAM` block on the Finder gap. |
+
+### Reused (shared lib)
+
+| File                | Used for                                                                     |
+| ------------------- | ---------------------------------------------------------------------------- |
+| `lib/api/items.ts`  | `fetchSecurityItem(itemId)` — wraps `GET /api/items/:itemId`.                |
+| `lib/api/client.ts` | `authFetch` (Bearer + token refresh on `TOKEN_EXPIRED`), `parseApiError`.    |
+| `types/items.ts`    | `SecurityItemDetail` / `SecurityItemImage` / `ItemStatus` response types.    |
+| `utils/auth.ts`     | (via client) `getAccessToken` / `getRefreshToken` / `setTokens` / `signOut`. |
+
+### Backend (consumed, owned by backend team)
+
+| File                          | What                                                                                      |
+| ----------------------------- | ----------------------------------------------------------------------------------------- |
+| `backend/src/routes/items.ts` | `GET /items/:itemId` (`securityItemDetailSelect`, `toSecurityItemDetailDto`), role-gated. |
+
+## 4. Field mapping (response → UI)
+
+`GET /api/items/:itemId` returns `SecurityItemDetail`. What the page actually shows:
+
+| UI label           | Source                                     | Notes                                                            |
+| ------------------ | ------------------------------------------ | ---------------------------------------------------------------- |
+| Item Name          | `title`                                    |                                                                  |
+| Category           | `category`                                 |                                                                  |
+| Date               | `dateFound`                                | `formatDate` → `en-CA` (YYYY-MM-DD); null → `—`.                 |
+| Location           | `locationFound`                            | null → `—`.                                                      |
+| Campus             | `campusName`                               |                                                                  |
+| Description        | `descriptionPublic ?? descriptionInternal` | null → `—`. (No separate internal/public distinction in the UI.) |
+| Is item picked up? | `status === 'claimed'` → `Yes` / `No`      | Crude proxy — see Gaps #3.                                       |
+| Registrant         | `registeredBy.firstName + lastName`        | Empty → `—`.                                                     |
+| Photo              | `images[0]?.imageUrl`                      | null → empty gray box; only the **first** image is shown.        |
+| **Finder**         | **STUB** → `—`                             | No data source — see NOTES block / Gaps #1.                      |
+| **Finder Contact** | **STUB** → `—`                             | No backend column — see Gaps #1.                                 |
+
+**Returned but not displayed:** `color`, `brand`, `descriptionInternal` (when a
+public one exists), `claims[]` (claimId / status / studentName), `campusId`,
+`foundItemReportId`, `retentionExpiryDate`, `createdAt`, `updatedAt`, `status`
+(used only to derive "picked up"), all images after the first.
+
+## 5. Current status
+
+**Working**
+
+- Fetch + the three render states (loading spinner / error card / loaded detail).
+- Race guard on `itemId` change (stale responses discarded).
+- Auth handled by `authFetch`: Bearer header, silent refresh on `TOKEN_EXPIRED`, `signOut` on hard 401.
+- Error card shows the backend message (or "Item not found.") + "Back to items".
+- Cancel navigates back to `/security/items`.
+- Responsive layout (fields beside photo on `lg`, stacked on mobile).
+
+**Stubbed / placeholder (intentional)**
+
+- **Finder** and **Finder Contact** — rendered as `—`; no real source (see NOTES block in the file).
+- **Release** button — no `onClick`, no endpoint. Does nothing (disabled while editing).
+- **Edit mode (frontend-only)** — Edit toggles `title`, `category`, `dateFound`,
+  `locationFound`, `description` into inputs (Item Name = text, Category = select
+  from `constants/categories.ts`, Date = native date, Location = text, Description =
+  textarea). **Save updates local React state only** — there is no `PATCH` endpoint,
+  so edits are lost on refresh. Cancel discards. Finder/Finder Contact, Campus, and
+  Registrant stay read-only.
+
+## 6. Known gaps / risks
+
+1. **Finder name + contact have no data source.** `GET /api/items/:itemId` doesn't
+   return them. The path would be `Item → foundItemReport → finder (User)`, but the
+   report records the **submitter** as the finder
+   (`backend/src/routes/reportLinks.ts` `finderId: req.user.user_id`), so "Finder"
+   would just equal the registrant. There's also no contact column on
+   `found_item_report` (closest is `user.phone`). **Decide the real source before
+   wiring these up.** Same gap is mirrored in `app/report-found/[token]/page.tsx`.
+2. **No Release endpoint/flow.** The red Release button is a placeholder — no
+   `POST`/status-transition endpoint, no student-ID verification step, no claim
+   linkage. The "_Verify student ID_" note is purely informational.
+3. **"Is item picked up?" is a proxy.** Derived from `status === 'claimed'`, not a
+   real pickup/handover record. Won't reflect `expired`/`disposed` nuance.
+4. **Edit doesn't persist.** Edit mode is wired on the frontend, but there's no
+   `PATCH /api/items/:itemId`, so Save only mutates local state — edits vanish on
+   refresh. Needs a backend update endpoint (+ validator) to become real.
+5. **Only the first image is shown.** `images[]` may hold several; gallery/multi-image
+   UI isn't built.
+6. **`claims[]` is fetched but unused.** Claim status/claimant aren't surfaced even
+   though they'd be the natural backing for release + "picked up".
+7. **No client role guard.** Security relies entirely on the backend role check; a
+   non-security user hitting the URL just sees an error from the API, not a redirect.
+
+## 7. How to test
+
+**Setup** (same as the rest of the app)
+
+```bash
+cd backend && pnpm install && npx prisma migrate dev && npx prisma db seed && pnpm dev
+cd foundit-ui && pnpm install && pnpm dev   # .env: NEXT_PUBLIC_API_URL=http://localhost:3001
+```
+
+**Run**
+
+1. Log in as a **security** user (seed: `carol@myseneca.ca` / `Test1234!`).
+2. Open `/security/items`, click an item — or hit `/security/items/<itemId>` directly
+   (grab a real `itemId` from the list response or `npx prisma studio` → `item`).
+
+**Matrix**
+
+| Case          | How                                    | Expect                                              |
+| ------------- | -------------------------------------- | --------------------------------------------------- |
+| Happy path    | open a valid item                      | spinner → detail with fields + photo                |
+| Not found     | use a bogus (well-formed) id           | error card "Item not found." + Back button          |
+| No image      | item with no `images`                  | empty gray placeholder box                          |
+| Null fields   | item missing location/description/date | each shows `—`                                      |
+| Picked up     | item with `status = claimed`           | "Is item picked up?" → Yes                          |
+| Wrong role    | log in as a student                    | error card (backend 403), no detail                 |
+| Not logged in | clear localStorage                     | `authFetch` throws "Not authenticated" → error card |
+| Cancel        | click Cancel (read mode)               | navigates to `/security/items`                      |
+| Enter edit    | click Edit                             | fields become inputs; buttons → Cancel / Save       |
+| Save edit     | change a field, click Save             | read mode shows new value (this session only)       |
+| Discard edit  | change a field, click Cancel (edit)    | reverts to original values, back to read mode       |
+
+## 8. Future work
+
+- **Backend:** decide the Finder identity/contact source (or drop both fields); add a
+  Release endpoint (status transition + ID-verification + claim linkage); add an item
+  update endpoint.
+- **Frontend:** point Save at `PATCH /api/items/:itemId` once it exists (swap
+  `handleSave`'s local `setItem` for a request + error handling); wire Release; surface `claims[]` and the
+  remaining `images[]`; replace the `status === 'claimed'` pickup proxy with a real
+  signal; consider a client-side role redirect for non-security users.


### PR DESCRIPTION
## ⚠️ Merge order
**This PR is stacked on #83 (\`Yun/security-items-list-page\`).** It targets that branch, not \`main\`.
**#83 must be merged first** — do not merge this PR until #83 is merged. Once #83 lands, GitHub will retarget this PR to \`main\` (or update the base manually) and the diff will collapse to just the item-detail changes.

## What this adds
- **Security item detail page** at \`/security/items/[itemId]\`, wired to \`GET /api/items/:itemId\` via \`fetchSecurityItem\` (Bearer auth + token refresh through \`authFetch\`).
- Render states: loading spinner / error card ("Back to items") / loaded detail, with a race guard on \`itemId\` change.
- **Frontend-only edit mode:** the Edit button toggles Item Name, Category (select), Date, Location, and Description into inputs. Save / Cancel replace Edit while editing; Release is disabled in edit mode.
- A status/flow doc at \`foundit-ui/docs/security-item-detail.md\`.

## Known gaps (documented in the doc + inline)
- **Save does not persist** — there is no \`PATCH /api/items/:itemId\` yet, so Save updates local React state only (edits are lost on refresh). Swap \`handleSave\` to call the endpoint once it exists.
- **Release** button is a placeholder (no endpoint).
- **Finder / Finder Contact** are stubs (\`—\`) — no real data source yet (mirrors the gap noted in the report-found page).

## Test
1. Log in as a security user (seed: \`carol@myseneca.ca\` / \`Test1234!\`).
2. Open \`/security/items\`, click an item.
3. Click **Edit**, change fields, **Save** → values update for the session; **Cancel** discards.

🤖 Generated with [Claude Code](https://claude.com/claude-code)