### PR TITLE
fix: report campus selection set by security and update schema etc

### DIFF
--- a/backend/src/routes/items.ts
+++ b/backend/src/routes/items.ts
@@ -11,8 +11,15 @@ import {
   listSecurityItemsQuerySchema,
   publicItemsQuerySchema,
   updateSecurityItemSchema,
+  createSecurityItemSchema,
   UpdateSecurityItemInput,
+  CreateSecurityItemInput,
 } from '../validators/items';
+import {
+  buildDescriptionInternal,
+  computeRetentionExpiryDate,
+  itemTitleFromDescription,
+} from '../utils/itemHelpers';
 
 const router = Router();
 const publicItemStatuses = [ItemStatus.stored] as const;
@@ -173,15 +180,6 @@ function buildSecurityItemListWhere(query: {
   }
 
   return where;
-}
-
-function computeRetentionExpiryDate(
-  dateFound: Date,
-  retentionDays: number
-): Date {
-  const expiry = new Date(dateFound);
-  expiry.setUTCDate(expiry.getUTCDate() + retentionDays);
-  return expiry;
 }
 
 async function toSecurityItemListDto(item: SecurityItemListRow) {
@@ -427,6 +425,148 @@ router.get(
       );
 
       res.status(200).json({ data, nextCursor });
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+/**
+ * @openapi
+ * /api/items:
+ *   post:
+ *     summary: Register a found item into inventory (security direct intake)
+ *     tags: [Items]
+ *     security:
+ *       - bearerAuth: []
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [campusId, itemDescription, category, locationFound, dateFound]
+ *             properties:
+ *               campusId:
+ *                 type: string
+ *                 format: uuid
+ *               itemDescription:
+ *                 type: string
+ *               category:
+ *                 type: string
+ *               locationFound:
+ *                 type: string
+ *               dateFound:
+ *                 type: string
+ *                 format: date
+ *               images:
+ *                 type: array
+ *     responses:
+ *       '201':
+ *         description: Created security item detail
+ *       '400':
+ *         description: Validation error
+ *       '401':
+ *         description: Missing or invalid token
+ *       '403':
+ *         description: Forbidden
+ *       '404':
+ *         description: Campus not found
+ */
+router.post(
+  '/items',
+  authenticate,
+  requireRole('security', 'admin'),
+  validate(createSecurityItemSchema),
+  async (req, res, next) => {
+    try {
+      const {
+        campusId,
+        itemDescription,
+        category,
+        locationFound,
+        dateFound,
+        images,
+      } = req.body as CreateSecurityItemInput;
+
+      const campus = await prisma.campus.findUnique({
+        where: { campusId },
+        select: { campusId: true, retentionDays: true },
+      });
+
+      if (!campus) {
+        res.status(404).json({
+          code: 'CAMPUS_NOT_FOUND',
+          message: 'Campus not found.',
+        });
+        return;
+      }
+
+      const item = await prisma.$transaction(async (tx) => {
+        const created = await tx.item.create({
+          data: {
+            campusId,
+            category,
+            title: itemTitleFromDescription(itemDescription, category),
+            descriptionInternal: buildDescriptionInternal(itemDescription),
+            locationFound,
+            dateFound,
+            status: ItemStatus.stored,
+            foundItemReportId: null,
+            registeredBy: req.user!.user_id,
+            retentionExpiryDate: computeRetentionExpiryDate(
+              dateFound,
+              campus.retentionDays
+            ),
+          },
+          select: {
+            itemId: true,
+          },
+        });
+
+        if (images.length > 0) {
+          await tx.itemImage.createMany({
+            data: images.map((image) => ({
+              itemId: created.itemId,
+              imageUrl: image.imageUrl,
+              uploadedBy: req.user!.user_id,
+              fileType: image.fileType,
+              fileSizeKb: image.fileSizeKb,
+            })),
+          });
+        }
+
+        return created;
+      });
+
+      const detail = await prisma.item.findUnique({
+        where: { itemId: item.itemId },
+        select: securityItemDetailSelect,
+      });
+
+      if (!detail) {
+        res.status(500).json({
+          code: 'INTERNAL_ERROR',
+          message: 'Item was created but could not be loaded.',
+        });
+        return;
+      }
+
+      await writeAuditLog({
+        actorId: req.user!.user_id,
+        action: 'item_created',
+        entityType: 'item',
+        entityId: detail.itemId,
+        details: {
+          title: detail.title,
+          category: detail.category,
+          campusId,
+          dateFound: dateFound.toISOString().slice(0, 10),
+        },
+        ipAddress: req.ip,
+      });
+
+      res.status(201).json(await toSecurityItemDetailDto(detail));
     } catch (err) {
       next(err);
     }

--- a/backend/src/routes/items.ts
+++ b/backend/src/routes/items.ts
@@ -3,12 +3,15 @@ import { ItemStatus, Prisma } from '@prisma/client';
 import { prisma } from '../db';
 import authenticate from '../middleware/authenticate';
 import requireRole from '../middleware/requireRole';
-import { validateQuery } from '../validators/shared';
+import { validateQuery, validate } from '../validators/shared';
 import { resolveImageUrl } from '../utils/imageUrl';
+import { writeAuditLog } from '../utils/auditLog';
 import {
   itemParamsSchema,
   listSecurityItemsQuerySchema,
   publicItemsQuerySchema,
+  updateSecurityItemSchema,
+  UpdateSecurityItemInput,
 } from '../validators/items';
 
 const router = Router();
@@ -170,6 +173,15 @@ function buildSecurityItemListWhere(query: {
   }
 
   return where;
+}
+
+function computeRetentionExpiryDate(
+  dateFound: Date,
+  retentionDays: number
+): Date {
+  const expiry = new Date(dateFound);
+  expiry.setUTCDate(expiry.getUTCDate() + retentionDays);
+  return expiry;
 }
 
 async function toSecurityItemListDto(item: SecurityItemListRow) {
@@ -472,6 +484,144 @@ router.get(
       }
 
       res.status(200).json(await toSecurityItemDetailDto(item));
+    } catch (err) {
+      next(err);
+    }
+  }
+);
+
+/**
+ * @openapi
+ * /api/items/{itemId}:
+ *   patch:
+ *     summary: Update item fields for security staff
+ *     tags: [Items]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: path
+ *         name: itemId
+ *         required: true
+ *         schema:
+ *           type: string
+ *           format: uuid
+ *     requestBody:
+ *       required: true
+ *       content:
+ *         application/json:
+ *           schema:
+ *             type: object
+ *             required: [title, category, dateFound, locationFound, descriptionInternal]
+ *             properties:
+ *               title:
+ *                 type: string
+ *               category:
+ *                 type: string
+ *               dateFound:
+ *                 type: string
+ *                 format: date
+ *               locationFound:
+ *                 type: string
+ *                 nullable: true
+ *               descriptionInternal:
+ *                 type: string
+ *                 nullable: true
+ *     responses:
+ *       '200':
+ *         description: Updated security item detail
+ *       '400':
+ *         description: Validation error
+ *       '401':
+ *         description: Missing or invalid token
+ *       '403':
+ *         description: Forbidden
+ *       '404':
+ *         description: Item not found
+ */
+router.patch(
+  '/items/:itemId',
+  authenticate,
+  requireRole('security', 'admin'),
+  validate(updateSecurityItemSchema),
+  async (req, res, next) => {
+    try {
+      const params = itemParamsSchema.safeParse(req.params);
+      if (!params.success) {
+        sendValidationError(res, params.error.issues);
+        return;
+      }
+
+      const existing = await prisma.item.findUnique({
+        where: { itemId: params.data.itemId },
+        select: {
+          itemId: true,
+          campusId: true,
+          dateFound: true,
+        },
+      });
+
+      if (!existing) {
+        res.status(404).json({
+          code: 'ITEM_NOT_FOUND',
+          message: 'Item not found.',
+        });
+        return;
+      }
+
+      const { title, category, dateFound, locationFound, descriptionInternal } =
+        req.body as UpdateSecurityItemInput;
+
+      const campus = await prisma.campus.findUnique({
+        where: { campusId: existing.campusId },
+        select: { retentionDays: true },
+      });
+
+      if (!campus) {
+        res.status(500).json({
+          code: 'INTERNAL_ERROR',
+          message: 'Item campus is no longer available.',
+        });
+        return;
+      }
+
+      const dateChanged =
+        existing.dateFound.toISOString().slice(0, 10) !==
+        dateFound.toISOString().slice(0, 10);
+
+      const updated = await prisma.item.update({
+        where: { itemId: existing.itemId },
+        data: {
+          title,
+          category,
+          dateFound,
+          locationFound,
+          descriptionInternal,
+          ...(dateChanged
+            ? {
+                retentionExpiryDate: computeRetentionExpiryDate(
+                  dateFound,
+                  campus.retentionDays
+                ),
+              }
+            : {}),
+        },
+        select: securityItemDetailSelect,
+      });
+
+      await writeAuditLog({
+        actorId: req.user!.user_id,
+        action: 'item_updated',
+        entityType: 'item',
+        entityId: updated.itemId,
+        details: {
+          title,
+          category,
+          dateFound: dateFound.toISOString().slice(0, 10),
+        },
+        ipAddress: req.ip,
+      });
+
+      res.status(200).json(await toSecurityItemDetailDto(updated));
     } catch (err) {
       next(err);
     }

--- a/backend/src/routes/reportLinks.ts
+++ b/backend/src/routes/reportLinks.ts
@@ -248,7 +248,7 @@ async function createReportLinkRecord(
  *               campusId:
  *                 type: string
  *                 format: uuid
- *                 description: Admin only; security uses their assigned campus
+ *                 description: Campus for the report link; defaults to the user's assigned campus
  *               expiresInMinutes:
  *                 type: integer
  *                 minimum: 5
@@ -263,8 +263,6 @@ async function createReportLinkRecord(
  *         description: Security or admin role required
  *       '404':
  *         description: Campus not found
- *       '409':
- *         description: Campus required for security user
  */
 router.post(
   '/',
@@ -281,47 +279,33 @@ router.post(
       const { campusId: bodyCampusId, expiresInMinutes } =
         req.body as CreateReportLinkInput;
 
-      let campusId: string;
+      const campusId = bodyCampusId ?? actor.campusId ?? '';
 
-      if (actor.role === 'security') {
-        if (!actor.campusId) {
-          res.status(409).json({
-            code: 'REPORT_LINK_CAMPUS_REQUIRED',
-            message:
-              'A campus must be assigned before a report link can be generated.',
-          });
-          return;
-        }
-        campusId = actor.campusId;
-      } else {
-        campusId = bodyCampusId ?? actor.campusId ?? '';
-        if (!campusId) {
-          res.status(400).json({
-            code: 'VALIDATION_ERROR',
-            message: 'Validation failed',
-            details: [
-              {
-                path: ['campusId'],
-                message:
-                  'campusId is required when admin has no campus assigned',
-              },
-            ],
-          });
-          return;
-        }
-
-        const campus = await prisma.campus.findUnique({
-          where: { campusId },
-          select: { campusId: true },
+      if (!campusId) {
+        res.status(400).json({
+          code: 'VALIDATION_ERROR',
+          message: 'Validation failed',
+          details: [
+            {
+              path: ['campusId'],
+              message: 'campusId is required',
+            },
+          ],
         });
+        return;
+      }
 
-        if (!campus) {
-          res.status(404).json({
-            code: 'CAMPUS_NOT_FOUND',
-            message: 'Campus not found.',
-          });
-          return;
-        }
+      const campus = await prisma.campus.findUnique({
+        where: { campusId },
+        select: { campusId: true },
+      });
+
+      if (!campus) {
+        res.status(404).json({
+          code: 'CAMPUS_NOT_FOUND',
+          message: 'Campus not found.',
+        });
+        return;
       }
 
       const expiresAt = new Date(Date.now() + expiresInMinutes * 60 * 1000);

--- a/backend/src/utils/itemHelpers.ts
+++ b/backend/src/utils/itemHelpers.ts
@@ -1,0 +1,27 @@
+export function itemTitleFromDescription(
+  description: string,
+  category: string
+): string {
+  const firstLine = description.split(/\r?\n/)[0]?.trim() || description.trim();
+  const title = firstLine || category;
+  return title.slice(0, 100);
+}
+
+export function buildDescriptionInternal(
+  itemDescription: string,
+  additionalNotes?: string
+): string {
+  if (additionalNotes) {
+    return `${itemDescription}\n\n${additionalNotes}`;
+  }
+  return itemDescription;
+}
+
+export function computeRetentionExpiryDate(
+  dateFound: Date,
+  retentionDays: number
+): Date {
+  const expiry = new Date(dateFound);
+  expiry.setUTCDate(expiry.getUTCDate() + retentionDays);
+  return expiry;
+}

--- a/backend/src/validators/items.ts
+++ b/backend/src/validators/items.ts
@@ -9,6 +9,12 @@ const itemStatusValues = [
   ItemStatus.disposed,
 ] as const;
 
+function getTodayAtMidnight() {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  return today;
+}
+
 export const publicItemsQuerySchema = z.object({
   category: z.string().min(1).max(50).trim().optional(),
   campusId: z.uuid().optional(),
@@ -25,3 +31,28 @@ export const listSecurityItemsQuerySchema = z.object({
 export const itemParamsSchema = z.object({
   itemId: z.uuid(),
 });
+
+export const updateSecurityItemSchema = z.object({
+  title: z.string().min(1).max(100).trim(),
+  category: z.string().min(1).max(50).trim(),
+  dateFound: z.iso
+    .date()
+    .transform((value) => new Date(`${value}T00:00:00.000Z`))
+    .refine((value) => value <= getTodayAtMidnight(), {
+      message: 'dateFound cannot be in the future',
+    }),
+  locationFound: z
+    .string()
+    .max(255)
+    .trim()
+    .transform((value) => value || null)
+    .nullable(),
+  descriptionInternal: z
+    .string()
+    .max(5000)
+    .trim()
+    .transform((value) => value || null)
+    .nullable(),
+});
+
+export type UpdateSecurityItemInput = z.infer<typeof updateSecurityItemSchema>;

--- a/backend/src/validators/items.ts
+++ b/backend/src/validators/items.ts
@@ -1,5 +1,6 @@
 import { ItemStatus } from '@prisma/client';
 import { z } from 'zod';
+import { reportImageSchema } from './reportLinks';
 
 const itemStatusValues = [
   ItemStatus.pending_report,
@@ -56,3 +57,19 @@ export const updateSecurityItemSchema = z.object({
 });
 
 export type UpdateSecurityItemInput = z.infer<typeof updateSecurityItemSchema>;
+
+export const createSecurityItemSchema = z.object({
+  campusId: z.uuid(),
+  itemDescription: z.string().min(1).max(1000).trim(),
+  category: z.string().min(1).max(50).trim(),
+  locationFound: z.string().min(1).max(100).trim(),
+  dateFound: z.iso
+    .date()
+    .transform((value) => new Date(`${value}T00:00:00.000Z`))
+    .refine((value) => value <= getTodayAtMidnight(), {
+      message: 'dateFound cannot be in the future',
+    }),
+  images: z.array(reportImageSchema).max(10).optional().default([]),
+});
+
+export type CreateSecurityItemInput = z.infer<typeof createSecurityItemSchema>;

--- a/backend/src/validators/reportLinks.ts
+++ b/backend/src/validators/reportLinks.ts
@@ -5,7 +5,9 @@ const locationSchema = z.string().min(1).max(100).trim();
 
 function getTodayAtMidnight() {
   const now = new Date();
-  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
+  return new Date(
+    Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate())
+  );
 }
 
 export const reportLinkTokenParamsSchema = z.object({

--- a/backend/src/validators/reportLinks.ts
+++ b/backend/src/validators/reportLinks.ts
@@ -4,9 +4,8 @@ const categorySchema = z.string().min(1).max(50).trim();
 const locationSchema = z.string().min(1).max(100).trim();
 
 function getTodayAtMidnight() {
-  const today = new Date();
-  today.setHours(0, 0, 0, 0);
-  return today;
+  const now = new Date();
+  return new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()));
 }
 
 export const reportLinkTokenParamsSchema = z.object({

--- a/backend/src/validators/reportLinks.ts
+++ b/backend/src/validators/reportLinks.ts
@@ -20,7 +20,7 @@ export const createReportLinkSchema = z.object({
 
 export type CreateReportLinkInput = z.infer<typeof createReportLinkSchema>;
 
-const reportImageSchema = z.object({
+export const reportImageSchema = z.object({
   imageUrl: z
     .string()
     .min(1)

--- a/foundit-ui/app/security/items/[itemId]/page.tsx
+++ b/foundit-ui/app/security/items/[itemId]/page.tsx
@@ -15,7 +15,7 @@ import {
   Text,
   Textarea,
 } from '@chakra-ui/react';
-import { fetchSecurityItem } from '@/lib/api/items';
+import { fetchSecurityItem, updateSecurityItem } from '@/lib/api/items';
 import { CATEGORIES } from '@/constants/categories';
 import type { SecurityItemDetail } from '@/types/items';
 
@@ -109,6 +109,8 @@ export default function SecurityItemDetailPage() {
   const [error, setError] = useState('');
   const [editing, setEditing] = useState(false);
   const [form, setForm] = useState<EditForm | null>(null);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState('');
 
   useEffect(() => {
     if (!itemId) return;
@@ -145,12 +147,13 @@ export default function SecurityItemDetailPage() {
 
   function handleStartEdit() {
     if (!item) return;
+    setSaveError('');
     setForm({
       title: item.title,
       category: item.category,
       dateFound: toDateInputValue(item.dateFound),
       locationFound: item.locationFound ?? '',
-      description: item.descriptionPublic ?? item.descriptionInternal ?? '',
+      description: item.descriptionInternal ?? item.descriptionPublic ?? '',
     });
     setEditing(true);
   }
@@ -158,6 +161,7 @@ export default function SecurityItemDetailPage() {
   function handleCancelEdit() {
     setEditing(false);
     setForm(null);
+    setSaveError('');
   }
 
   function handleFormChange<K extends keyof EditForm>(
@@ -167,20 +171,30 @@ export default function SecurityItemDetailPage() {
     setForm((prev) => (prev ? { ...prev, [key]: value } : prev));
   }
 
-  // TODO(backend): no PATCH /api/items/:itemId yet — Save only updates local
-  // state so the edit is visible for this session; it does NOT persist.
-  function handleSave() {
-    if (!item || !form) return;
-    setItem({
-      ...item,
-      title: form.title,
-      category: form.category,
-      dateFound: form.dateFound,
-      locationFound: form.locationFound.trim() || null,
-      descriptionPublic: form.description.trim() || null,
-    });
-    setEditing(false);
-    setForm(null);
+  async function handleSave() {
+    if (!item || !form || !itemId || saving) return;
+
+    setSaving(true);
+    setSaveError('');
+
+    try {
+      const updated = await updateSecurityItem(itemId, {
+        title: form.title.trim(),
+        category: form.category.trim(),
+        dateFound: form.dateFound,
+        locationFound: form.locationFound.trim() || null,
+        descriptionInternal: form.description.trim() || null,
+      });
+      setItem(updated);
+      setEditing(false);
+      setForm(null);
+    } catch (err) {
+      setSaveError(
+        err instanceof Error ? err.message : 'Failed to save item changes.'
+      );
+    } finally {
+      setSaving(false);
+    }
   }
 
   if (loading) {
@@ -209,25 +223,14 @@ export default function SecurityItemDetailPage() {
     PLACEHOLDER;
   const pickedUp = item.status === 'claimed' ? 'Yes' : 'No';
   const description =
-    item.descriptionPublic ?? item.descriptionInternal ?? PLACEHOLDER;
+    item.descriptionInternal ?? item.descriptionPublic ?? PLACEHOLDER;
   const photoUrl = item.images[0]?.imageUrl ?? null;
 
-  // ─── NOTES FOR THE TEAM ────────────────────────────────────────────────────
-  // Finder name + Finder Contact have no real data source yet (kept UI-only):
-  //   • GET /api/items/:itemId does not return them. The path would be
-  //     Item -> foundItemReport -> finder (User), exposed via
-  //     securityItemDetailSelect, toSecurityItemDetailDto, and SecurityItemDetail.
-  //   • Caveat: the report link carries no finder identity — the backend records
-  //     the SUBMITTER as the finder (backend/src/routes/reportLinks.ts:326,
-  //     finderId: req.user!.user_id), so "Finder" would just equal the
-  //     registrant/submitter. There is also no contact column on
-  //     found_item_report (closest is user.phone), so "Finder Contact" has no
-  //     true source. Decide the real source before wiring these up.
-  //   • Same gap is documented on the other side in
-  //     app/report-found/[token]/page.tsx ("NOTES FOR THE TEAM").
-  // ───────────────────────────────────────────────────────────────────────────
-  const finderName = PLACEHOLDER;
-  const finderContact = PLACEHOLDER;
+  const finderName = item.finder
+    ? `${item.finder.firstName} ${item.finder.lastName}`.trim() || PLACEHOLDER
+    : PLACEHOLDER;
+  const finderContact =
+    item.finder?.phone?.trim() || item.finder?.email?.trim() || PLACEHOLDER;
 
   return (
     <Box
@@ -414,34 +417,48 @@ export default function SecurityItemDetailPage() {
       </Stack>
 
       {/* Actions */}
-      <Flex justify="center" gap="26px" mt="64px">
-        <Button
-          variant="outline"
-          w="155px"
-          h="42px"
-          borderColor="#ddd"
-          color="#666"
-          fontSize="16px"
-          fontWeight="medium"
-          borderRadius="4px"
-          onClick={editing ? handleCancelEdit : handleCancel}
-        >
-          Cancel
-        </Button>
-        {/* TODO(backend): no PATCH /api/items/:itemId yet — Save updates local
-            state only (no persistence). See handleSave. */}
-        <Button
-          w="155px"
-          h="42px"
-          bg="#3b82f6"
-          color="white"
-          fontSize="16px"
-          fontWeight="medium"
-          borderRadius="4px"
-          onClick={editing ? handleSave : handleStartEdit}
-        >
-          {editing ? 'Save' : 'Edit'}
-        </Button>
+      <Flex
+        justify="center"
+        gap="26px"
+        mt="64px"
+        direction="column"
+        align="center"
+      >
+        {saveError ? (
+          <Text fontSize="sm" color="red.500">
+            {saveError}
+          </Text>
+        ) : null}
+        <Flex justify="center" gap="26px">
+          <Button
+            variant="outline"
+            w="155px"
+            h="42px"
+            borderColor="#ddd"
+            color="#666"
+            fontSize="16px"
+            fontWeight="medium"
+            borderRadius="4px"
+            onClick={editing ? handleCancelEdit : handleCancel}
+            disabled={saving}
+          >
+            Cancel
+          </Button>
+          <Button
+            w="155px"
+            h="42px"
+            bg="#3b82f6"
+            color="white"
+            fontSize="16px"
+            fontWeight="medium"
+            borderRadius="4px"
+            onClick={editing ? handleSave : handleStartEdit}
+            loading={saving}
+            disabled={saving}
+          >
+            {editing ? 'Save' : 'Edit'}
+          </Button>
+        </Flex>
       </Flex>
     </Box>
   );

--- a/foundit-ui/app/security/qr/page.tsx
+++ b/foundit-ui/app/security/qr/page.tsx
@@ -63,7 +63,6 @@ function ReadOnlyField({ label, value }: { label: string; value: string }) {
 
 export default function GenerateQrPage() {
   const loggedInUser = getLoggedInUser();
-  const isAdmin = loggedInUser?.role === 'admin';
 
   const [campuses, setCampuses] = useState<Campus[]>([]);
   const [campusId, setCampusId] = useState('');
@@ -114,9 +113,6 @@ export default function GenerateQrPage() {
     );
   }, [campuses, campusId]);
 
-  const campusSelectDisabled =
-    !isAdmin && Boolean(loggedInUser?.campusId && campusId);
-
   useEffect(() => {
     if (!generated) return;
 
@@ -142,7 +138,7 @@ export default function GenerateQrPage() {
 
     try {
       const result = await createReportLink(
-        isAdmin && campusId ? { campusId } : undefined
+        campusId ? { campusId } : undefined
       );
 
       const campusName =
@@ -162,7 +158,7 @@ export default function GenerateQrPage() {
     } finally {
       setGenerating(false);
     }
-  }, [campuses, campusId, isAdmin, selectedCampusName]);
+  }, [campuses, campusId, selectedCampusName]);
 
   const handleCopyLink = async () => {
     if (!generated?.url) return;
@@ -182,8 +178,7 @@ export default function GenerateQrPage() {
     setError('');
   };
 
-  const canGenerate =
-    !loadingCampuses && !generating && (isAdmin ? Boolean(campusId) : true);
+  const canGenerate = !loadingCampuses && !generating && Boolean(campusId);
 
   return (
     <Stack gap={6}>
@@ -227,7 +222,6 @@ export default function GenerateQrPage() {
                 <Select
                   value={campusId}
                   onChange={(e) => setCampusId(e.target.value)}
-                  disabled={campusSelectDisabled}
                   h={12}
                   px={4}
                   fontSize="md"

--- a/foundit-ui/components/Navbar.tsx
+++ b/foundit-ui/components/Navbar.tsx
@@ -6,7 +6,7 @@
  * Variants:
  *   'guest'    — not logged in; no username, shows Login button.
  *   'student'  — authenticated student; shows Home, Found Items, My Claims + user dropdown.
- *   'security' — authenticated security staff; shows Home, Items, Claims, QR/Link + user dropdown.
+ *   'security' — authenticated security staff; shows Home, Items, Claims, Report Found Item + user dropdown.
  *
  * Data shape:
  *   The parent calls GET /api/users/me (returns NavUser), then passes
@@ -165,7 +165,7 @@ const navLinksByVariant: Record<
     { label: 'Home', href: '/security/dashboard' },
     { label: 'Items', href: '/security/items' },
     { label: 'Claims', href: '/security/claims' },
-    { label: 'QR / Link', href: '/security/qr' },
+    { label: 'Report Found Item', href: '/security/report-found' },
   ],
 };
 

--- a/foundit-ui/lib/api/items.ts
+++ b/foundit-ui/lib/api/items.ts
@@ -58,3 +58,57 @@ export async function fetchSecurityItem(
 
   return res.json() as Promise<SecurityItemDetail>;
 }
+
+export interface UpdateSecurityItemInput {
+  title: string;
+  category: string;
+  dateFound: string;
+  locationFound: string | null;
+  descriptionInternal: string | null;
+}
+
+export async function updateSecurityItem(
+  itemId: string,
+  input: UpdateSecurityItemInput
+): Promise<SecurityItemDetail> {
+  const res = await authFetch(`${API_BASE}/api/items/${itemId}`, {
+    method: 'PATCH',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+
+  if (!res.ok) {
+    throw new Error(await parseApiError(res));
+  }
+
+  return res.json() as Promise<SecurityItemDetail>;
+}
+
+export interface CreateSecurityItemInput {
+  campusId: string;
+  itemDescription: string;
+  category: string;
+  locationFound: string;
+  dateFound: string;
+  images?: {
+    imageUrl: string;
+    fileType: string;
+    fileSizeKb: number;
+  }[];
+}
+
+export async function createSecurityItem(
+  input: CreateSecurityItemInput
+): Promise<SecurityItemDetail> {
+  const res = await authFetch(`${API_BASE}/api/items`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(input),
+  });
+
+  if (!res.ok) {
+    throw new Error(await parseApiError(res));
+  }
+
+  return res.json() as Promise<SecurityItemDetail>;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Security staff can now register and persist found item details, including computed retention expiry from the found date.
  * Security staff can edit item information (title, category, found date, location, and internal description) with changes saved to the system.
  * Item details now show actual finder contact information.

* **Bug Fixes**
  * QR code generation and campus selection are now consistent across user types.
  * Report link creation validation and campus handling were improved for clearer errors and correct defaults.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->