### PR TITLE
Fix claim-item hydration/setState bugs; upload claim images to R2

### DIFF
--- a/backend/src/routes/claims.ts
+++ b/backend/src/routes/claims.ts
@@ -15,6 +15,7 @@ import {
   claimAndMatchParamsSchema,
   claimParamsSchema,
   createClaimSchema,
+  type CreateClaimInput,
   linkClaimItemSchema,
   listClaimsQuerySchema,
   reviewMatchSuggestionSchema,
@@ -439,6 +440,19 @@ function scoreCandidateItem(
  *                 format: date
  *               locationLost:
  *                 type: string
+ *               images:
+ *                 type: array
+ *                 maxItems: 3
+ *                 items:
+ *                   type: object
+ *                   required: [imageUrl, fileType, fileSizeKb]
+ *                   properties:
+ *                     imageUrl:
+ *                       type: string
+ *                     fileType:
+ *                       type: string
+ *                     fileSizeKb:
+ *                       type: integer
  *     responses:
  *       '201':
  *         description: Claim created
@@ -469,22 +483,34 @@ router.post(
         return;
       }
 
-      const payload = req.body as {
-        category: string;
-        description: string;
-        dateLost?: Date;
-        locationLost?: string;
-      };
-      const claim = await prisma.claim.create({
-        data: {
-          studentId: actor.userId,
-          campusId: actor.campusId,
-          category: payload.category,
-          description: payload.description,
-          dateLost: payload.dateLost,
-          locationLost: payload.locationLost,
-        },
-        select: claimDetailSelect,
+      const payload = req.body as CreateClaimInput;
+      const campusId = actor.campusId;
+      const claim = await prisma.$transaction(async (tx) => {
+        const created = await tx.claim.create({
+          data: {
+            studentId: actor.userId,
+            campusId,
+            category: payload.category,
+            description: payload.description,
+            dateLost: payload.dateLost,
+            locationLost: payload.locationLost,
+          },
+          select: claimDetailSelect,
+        });
+
+        if (payload.images.length > 0) {
+          await tx.itemImage.createMany({
+            data: payload.images.map((image) => ({
+              claimId: created.claimId,
+              imageUrl: image.imageUrl,
+              uploadedBy: actor.userId,
+              fileType: image.fileType,
+              fileSizeKb: image.fileSizeKb,
+            })),
+          });
+        }
+
+        return created;
       });
 
       await writeAuditLog({

--- a/backend/src/validators/claims.ts
+++ b/backend/src/validators/claims.ts
@@ -1,5 +1,6 @@
 import { ClaimStatus, MatchStatus } from '@prisma/client';
 import { z } from 'zod';
+import { reportImageSchema } from './reportLinks';
 
 const claimStatusValues = [
   ClaimStatus.submitted,
@@ -34,7 +35,12 @@ export const createClaimSchema = z.object({
   description: z.string().min(1).max(2000).trim(),
   dateLost: optionalDateSchema,
   locationLost: z.string().min(1).max(255).trim().optional(),
+  // Proof-of-ownership photos, uploaded to R2 client-side beforehand (same
+  // presigned-url flow as found-item reports); max 3 matches the gallery cap.
+  images: z.array(reportImageSchema).max(3).optional().default([]),
 });
+
+export type CreateClaimInput = z.infer<typeof createClaimSchema>;
 
 export const listClaimsQuerySchema = z.object({
   status: z.enum(claimStatusValues).optional(),

--- a/foundit-ui/app/student/claim-item/page.tsx
+++ b/foundit-ui/app/student/claim-item/page.tsx
@@ -18,7 +18,9 @@ import { LuCircleAlert } from 'react-icons/lu';
 import { CATEGORIES } from '@/constants/categories';
 import { useClaimItemForm } from '@/hooks/useClaimItemForm';
 import { useLoggedInDisplayName } from '@/hooks/useLoggedInDisplayName';
-import { getAccessToken, getLoggedInUser } from '@/utils/auth';
+import { useAccessToken } from '@/hooks/useAccessToken';
+import { useLoggedInUser } from '@/hooks/useLoggedInUser';
+import { getAccessToken } from '@/utils/auth';
 import { API_BASE, authFetch } from '@/lib/api/client';
 import { debugLog, debugWarn } from '@/utils/debug';
 
@@ -46,9 +48,9 @@ import { debugLog, debugWarn } from '@/utils/debug';
 //   2. Item Name, Notification preferences + Additional Information — rendered
 //      for design parity but NOT sent; createClaimSchema has no matching
 //      columns. See the hook's STUB FIELDS note.
-//   3. Proof-of-ownership images are staged as Files but never uploaded or
-//      sent — POST /api/claims has no image field. Mirror report-found's
-//      submit-time handleImageUpload loop once the backend accepts them.
+//   3. Proof-of-ownership images are uploaded to R2 at submit time (same
+//      handleImageUpload/presigned-url flow as report-found) and linked to
+//      the claim via ItemImage.claimId.
 // ─────────────────────────────────────────────────────────────────────────────
 
 export default function ClaimItemPage() {
@@ -115,8 +117,8 @@ function ClaimForm({ displayName }: { displayName: string }) {
   const form = useClaimItemForm();
   // Real session data (utils/auth.ts) — the identity rows and the student-only
   // gate the backend enforces. No mock data on this form.
-  const accessToken = getAccessToken();
-  const user = getLoggedInUser();
+  const accessToken = useAccessToken();
+  const user = useLoggedInUser();
   const isStudent = user?.role === 'student';
 
   // The login payload has no studentNumber or phone, so fetch both from the

--- a/foundit-ui/docs/report-found-form.md
+++ b/foundit-ui/docs/report-found-form.md
@@ -1,7 +1,7 @@
 # Report Found Item — Flow & Status
 
 > Status doc for the **Report Found Item** feature. Reflects the implementation as
-> of 2026-06-15. Safe to commit/share (unlike the local-only `plan.md` /
+> of 2026-07-06. Safe to commit/share (unlike the local-only `plan.md` /
 > `implementation.md`).
 
 ## 1. What it is
@@ -36,8 +36,9 @@ Route: `app/report-found/[token]/page.tsx` → URL `/report-found/<token>`.
         │
         ▼  Submit
         │     POST /api/report-links/:token/submit          (Bearer + student role, 10/15min)
-        │     body { itemDescription, category, locationFound, dateFound }
-        │     → 201: creates FoundItemReport (finderId = caller), consumes the link
+        │     body { title, description, category, locationFound, dateFound, images[] }
+        │     → 201: creates FoundItemReport + Item (finderId = caller), links any
+        │       uploaded images to the Item via ItemImage, consumes the link
         │     → 4xx mapped to a friendly message (see status map)
         └─ on success → router.push(ROLE_HOME.student)  (/student/dashboard)
 ```
@@ -69,7 +70,7 @@ Backend rules enforced on submit:
 
 | File                                                                                        | Used for                                                             |
 | ------------------------------------------------------------------------------------------- | -------------------------------------------------------------------- |
-| `components/uploadImage.tsx` (`ImageUploadGallery`)                                         | Image upload UI (uploads to R2 on select).                           |
+| `components/ImageUploadGallery.tsx`                                                         | Image upload UI (uploads to R2 on select).                           |
 | `hooks/useImageUploadGallery.ts`, `utils/handleImageUpload.ts`, `utils/imageCompression.ts` | Upload pipeline (presign → PUT) + compression.                       |
 | `utils/auth.ts`                                                                             | `getAccessToken` (Bearer), `getLoggedInUser` (identity + role gate). |
 | `hooks/useLoggedInDisplayName.ts`                                                           | Display name for Navbar + Finder/Registrant rows.                    |
@@ -88,22 +89,23 @@ Backend rules enforced on submit:
 
 ## 4. Field mapping (form → backend)
 
-`submitFoundItemReportSchema` accepts exactly: `itemDescription` (≤1000),
-`category` (≤50), `locationFound` (≤100), `dateFound` (YYYY-MM-DD, not future).
+`submitFoundItemReportSchema` accepts: `title` (≤100), `description` (≤1000),
+`category` (≤50), `locationFound` (≤100), `dateFound` (YYYY-MM-DD, not future),
+`images[]` (≤10, each `{ imageUrl, fileType, fileSizeKb }`).
 `timeFound` / `additionalNotes` are valid optional columns but **not exposed**
 (the design omits them).
 
-| Form field                      | Required | Sent as                   | Notes                                                                                                                                |
-| ------------------------------- | -------- | ------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
-| Item Name                       | ✅       | part of `itemDescription` | No DB column → folded into the description's first line (no data lost).                                                              |
-| Category                        | ✅       | `category`                | Free-text column; dropdown is a product choice (`constants/categories.ts`).                                                          |
-| Date                            | ✅       | `dateFound`               | Native date input, `max=today`, not-future validated.                                                                                |
-| Contact Information             | ✅       | — (**STUB**, not sent)    | No report column (only `User.phone`, a profile field).                                                                               |
-| Location                        | ✅       | `locationFound`           |                                                                                                                                      |
-| Campus                          | ✅       | — (**STUB**, not sent)    | `campusId` exists on `report_link`/`user`/`item` and is **derived + validated from the link** server-side; the picker is decorative. |
-| Image                           | optional | — (not linked)            | Uploads to R2 but the submit schema has no image field → orphaned.                                                                   |
-| Description                     | ✅       | `itemDescription`         | Combined `Item Name + Description` validated against the 1000 cap.                                                                   |
-| Finder / Registrant (read-only) | —        | —                         | Both fall back to the logged-in user; the link carries no separate identity.                                                         |
+| Form field                      | Required | Sent as                | Notes                                                                                                                                |
+| ------------------------------- | -------- | ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
+| Item Name                       | ✅       | `title`                | Route folds `title` + `description` into the report/item's internal description column server-side.                                  |
+| Category                        | ✅       | `category`             | Free-text column; dropdown is a product choice (`constants/categories.ts`).                                                          |
+| Date                            | ✅       | `dateFound`            | Native date input, `max=today`, not-future validated.                                                                                |
+| Contact Information             | ✅       | — (**STUB**, not sent) | No report column (only `User.phone`, a profile field).                                                                               |
+| Location                        | ✅       | `locationFound`        |                                                                                                                                      |
+| Campus                          | ✅       | — (**STUB**, not sent) | `campusId` exists on `report_link`/`user`/`item` and is **derived + validated from the link** server-side; the picker is decorative. |
+| Image                           | optional | `images[]`             | Uploaded to R2 on select; submitted keys are linked to the created `Item` via `ItemImage` in the same transaction.                   |
+| Description                     | ✅       | `description`          |                                                                                                                                      |
+| Finder / Registrant (read-only) | —        | —                      | Both fall back to the logged-in user; the link carries no separate identity.                                                         |
 
 ## 5. Current status
 
@@ -123,7 +125,7 @@ Backend rules enforced on submit:
 
 ## 6. Known gaps / risks
 
-1. **Images never linked to the report** — submit schema has no image field, so uploaded R2 objects are orphaned. Needs backend to accept image refs (+ create `ItemImage`).
+1. ~~**Images never linked to the report**~~ — **Done**. Submit schema accepts `images[]`; the route creates `ItemImage` rows (`itemId`) in the same transaction as the report/item.
 2. **No R2 cleanup** + the gallery's remove doesn't delete from R2 → orphans accumulate.
 3. **Immediate upload is fragile** — access token lives **15 min** with no refresh; uploads 401 if the user lingers.
 4. **R2 bucket has no CORS policy** for `http://localhost:3000` → browser PUT is blocked locally until a CORS policy is added.
@@ -173,6 +175,6 @@ report link token `dev-sample-token-abc123` (Newnham, 7-day expiry).
 
 ## 8. Future work
 
-- Backend: accept image refs on submit; consider a contact column or drop the field; `GET /api/report-links` list for security.
-- Frontend: when backend supports it, wire `imageRefs` into the submit body (one line in the hook); resolve campus name on report form; align stubs to reality (Campus read-only, drop Contact/Registrant).
+- Backend: consider a contact column or drop the field; `GET /api/report-links` list for security; R2 lifecycle rule/cleanup for removed or orphaned images.
+- Frontend: resolve campus name on report form; align stubs to reality (Campus read-only, drop Contact/Registrant).
 - Infra: R2 CORS policy for dev origins; R2 lifecycle rule to reap orphaned `reports/` objects.

--- a/foundit-ui/hooks/useClaimItemForm.ts
+++ b/foundit-ui/hooks/useClaimItemForm.ts
@@ -5,6 +5,8 @@ import { useRouter } from 'next/navigation';
 import { ApiError, apiFetch } from '@/lib/api/client';
 import { CLAIM_SUBMITTED_PATH } from '@/utils/routes';
 import { debugError, debugLog, debugWarn } from '@/utils/debug';
+import handleImageUpload from '@/utils/handleImageUpload';
+import { getAccessToken } from '@/utils/auth';
 
 // Backend caps (createClaimSchema): category ≤ 50, description ≤ 2000.
 const DESCRIPTION_MAX = 2000;
@@ -42,10 +44,8 @@ export function useClaimItemForm() {
   const [notificationPreference, setNotificationPreference] =
     useState<NotificationPreference>('email');
   const [additionalInformation, setAdditionalInformation] = useState('');
-  // Fed by the image gallery as raw Files (upload happens at submit time in
-  // the report-found flow). Intentionally NOT uploaded or sent here —
-  // POST /api/claims has no image field yet. Mirror useReportFoundItemForm's
-  // handleImageUpload loop once the backend accepts claim images.
+  // Fed by the image gallery as raw Files; uploaded to R2 at submit time
+  // (same handleImageUpload/presigned-url flow as useReportFoundItemForm).
   const [imageFiles, setImageFiles] = useState<File[]>([]);
 
   const [errors, setErrors] = useState<Record<string, string>>({});
@@ -121,24 +121,43 @@ export function useClaimItemForm() {
     debugLog('claim-form', 'submitting claim', {
       category,
       descriptionLength: description.trim().length,
+      imageFileCount: imageFiles.length,
       droppedStubFields: {
         itemNameLength: itemName.trim().length,
         notificationPreference,
         additionalInformationLength: additionalInformation.trim().length,
-        imageFileCount: imageFiles.length,
       },
     });
 
     setIsSubmitting(true);
     try {
+      const uploadedImages: {
+        imageUrl: string;
+        fileType: string;
+        fileSizeKb: number;
+      }[] = [];
+
+      const accessToken = getAccessToken();
+      if (accessToken) {
+        for (const file of imageFiles) {
+          const result = await handleImageUpload(file, accessToken);
+          uploadedImages.push({
+            imageUrl: result.imageUrl,
+            fileType: result.fileType,
+            fileSizeKb: result.fileSizeKb,
+          });
+        }
+      }
+
       const claim = await apiFetch<{ claimId?: string }>('/api/claims', {
         method: 'POST',
         body: JSON.stringify({
           category: category.trim(),
           description: description.trim(),
-          // NOTE: itemName, notificationPreference, additionalInformation
-          // and imageFiles are intentionally omitted — they are stub fields
-          // with no backend column (see state declarations).
+          images: uploadedImages,
+          // NOTE: itemName, notificationPreference and additionalInformation
+          // are intentionally omitted — they are stub fields with no backend
+          // column (see state declarations).
         }),
       });
 
@@ -152,10 +171,12 @@ export function useClaimItemForm() {
         debugWarn('claim-form', `claim rejected by backend (${err.status})`);
         setSubmitError(messageForStatus(err.status));
       } else {
-        // status 0: config/network failure — apiFetch's message says which.
+        // status 0 (config/network failure): apiFetch's message says which.
+        // A plain Error here means handleImageUpload threw during the
+        // presign/PUT-to-R2 step — fall back to the generic copy.
         debugError('claim-form', 'claim submit threw', err);
         setSubmitError(
-          err instanceof ApiError ? err.message : messageForStatus(401)
+          err instanceof ApiError ? err.message : messageForStatus(0)
         );
       }
       setIsSubmitting(false);

--- a/foundit-ui/hooks/useImageUploadGallery.ts
+++ b/foundit-ui/hooks/useImageUploadGallery.ts
@@ -37,31 +37,25 @@ export function useImageUploadGallery({
     const remainingSlots = MAX_IMAGES - images.length;
     const filesToProcess = files.slice(0, remainingSlots);
 
+    let next = images;
     for (const file of filesToProcess) {
       const previewUrl = URL.createObjectURL(file);
-
-      setImages((prev) => {
-        const next = [
-          ...prev,
-          { previewUrl, file, status: 'pending' as const },
-        ];
-
-        notifyChange(next);
-        return next;
-      });
+      next = [...next, { previewUrl, file, status: 'pending' as const }];
     }
+
+    setImages(next);
+    notifyChange(next);
 
     if (inputRef.current) inputRef.current.value = '';
   };
 
   const handleRemove = (previewUrl: string) => {
-    setImages((prev) => {
-      const removed = prev.find((img) => img.previewUrl === previewUrl);
-      if (removed) URL.revokeObjectURL(removed.previewUrl);
-      const next = prev.filter((img) => img.previewUrl !== previewUrl);
-      notifyChange(next);
-      return next;
-    });
+    const removed = images.find((img) => img.previewUrl === previewUrl);
+    if (removed) URL.revokeObjectURL(removed.previewUrl);
+    const next = images.filter((img) => img.previewUrl !== previewUrl);
+
+    setImages(next);
+    notifyChange(next);
   };
 
   return {

--- a/foundit-ui/hooks/useLoggedInUser.ts
+++ b/foundit-ui/hooks/useLoggedInUser.ts
@@ -1,0 +1,28 @@
+'use client';
+
+import { useSyncExternalStore } from 'react';
+import { getLoggedInUser, type LoggedInUser } from '@/utils/auth';
+
+const subscribe = () => () => {};
+
+// getLoggedInUser() re-parses localStorage into a new object every call;
+// useSyncExternalStore requires a referentially stable snapshot when nothing
+// changed, or React reschedules a render every commit and loops forever.
+let cachedRaw: string | null = null;
+let cachedUser: LoggedInUser | null = null;
+
+function getSnapshot(): LoggedInUser | null {
+  if (typeof window === 'undefined') return null;
+
+  const raw = localStorage.getItem('user');
+  if (raw !== cachedRaw) {
+    cachedRaw = raw;
+    cachedUser = getLoggedInUser();
+  }
+  return cachedUser;
+}
+
+/** Reads the stored user on the client after hydration; null on server/hydration. */
+export function useLoggedInUser(): LoggedInUser | null {
+  return useSyncExternalStore(subscribe, getSnapshot, () => null);
+}

--- a/foundit-ui/tests/hooks/useClaimItemForm.test.ts
+++ b/foundit-ui/tests/hooks/useClaimItemForm.test.ts
@@ -2,6 +2,8 @@ import { act, renderHook } from '@testing-library/react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { ApiError, apiFetch } from '@/lib/api/client';
 import { useClaimItemForm } from '@/hooks/useClaimItemForm';
+import { getAccessToken } from '@/utils/auth';
+import handleImageUpload from '@/utils/handleImageUpload';
 
 const pushMock = vi.fn();
 const backMock = vi.fn();
@@ -15,7 +17,16 @@ vi.mock('@/lib/api/client', async (importOriginal) => {
   return { ...actual, apiFetch: vi.fn() };
 });
 
+vi.mock('@/utils/auth', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/utils/auth')>();
+  return { ...actual, getAccessToken: vi.fn() };
+});
+
+vi.mock('@/utils/handleImageUpload', () => ({ default: vi.fn() }));
+
 const apiFetchMock = vi.mocked(apiFetch);
+const getAccessTokenMock = vi.mocked(getAccessToken);
+const handleImageUploadMock = vi.mocked(handleImageUpload);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -77,11 +88,69 @@ describe('useClaimItemForm', () => {
       body: JSON.stringify({
         category: 'Electronics',
         description: 'Black backpack',
+        images: [],
       }),
     });
     expect(pushMock).toHaveBeenCalledWith('/student/claim-item/submitted');
     // Stays true through the route transition to block duplicate submits.
     expect(result.current.isSubmitting).toBe(true);
+  });
+
+  it('uploads staged images to R2 and includes them in the claim payload', async () => {
+    getAccessTokenMock.mockReturnValue('token-123');
+    handleImageUploadMock.mockResolvedValueOnce({
+      imageUrl: 'reports/abc.jpg',
+      fileType: 'jpg',
+      fileSizeKb: 120,
+    });
+    apiFetchMock.mockResolvedValueOnce({ claimId: 'claim-1' });
+    const { result } = renderHook(() => useClaimItemForm());
+    const file = new File(['x'], 'proof.jpg', { type: 'image/jpeg' });
+
+    act(() => {
+      result.current.setCategory('Electronics');
+      result.current.setItemName('MacBook Pro');
+      result.current.setDescription('Black backpack');
+      result.current.setImageFiles([file]);
+    });
+    await act(() => result.current.handleSubmit());
+
+    expect(handleImageUploadMock).toHaveBeenCalledWith(file, 'token-123');
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/claims', {
+      method: 'POST',
+      body: JSON.stringify({
+        category: 'Electronics',
+        description: 'Black backpack',
+        images: [
+          { imageUrl: 'reports/abc.jpg', fileType: 'jpg', fileSizeKb: 120 },
+        ],
+      }),
+    });
+  });
+
+  it('skips uploading when there is no access token', async () => {
+    getAccessTokenMock.mockReturnValue(null);
+    apiFetchMock.mockResolvedValueOnce({ claimId: 'claim-1' });
+    const { result } = renderHook(() => useClaimItemForm());
+    const file = new File(['x'], 'proof.jpg', { type: 'image/jpeg' });
+
+    act(() => {
+      result.current.setCategory('Electronics');
+      result.current.setItemName('MacBook Pro');
+      result.current.setDescription('Black backpack');
+      result.current.setImageFiles([file]);
+    });
+    await act(() => result.current.handleSubmit());
+
+    expect(handleImageUploadMock).not.toHaveBeenCalled();
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/claims', {
+      method: 'POST',
+      body: JSON.stringify({
+        category: 'Electronics',
+        description: 'Black backpack',
+        images: [],
+      }),
+    });
   });
 
   it('maps backend statuses to user-facing copy', async () => {


### PR DESCRIPTION
## Summary
- Fix hydration mismatch on the Claim Item page: `ClaimForm` read `getAccessToken()`/`getLoggedInUser()` directly during render (server has no `window`, client's hydrating pass does), causing the identity rows to differ between SSR and client output. Routed both through `useSyncExternalStore`-based hooks (`useAccessToken`, new `useLoggedInUser`) with a stable server snapshot.
- Fix "Cannot update a component while rendering a different component" in `useImageUploadGallery`: `notifyChange` (which calls the parent's `setImageFiles`) was invoked from inside the `setImages` functional updater, which React can call during render. It's now computed and called as a separate step from the event handler.
- Wire claim proof-of-ownership images all the way through: `createClaimSchema` accepts `images[]` (reusing `reportImageSchema`), `POST /api/claims` persists `ItemImage` rows linked via `claimId` in the same transaction as the claim (mirrors how found-item reports link images via `itemId`), and `useClaimItemForm` uploads staged files to R2 at submit time instead of discarding them.
- Synced `docs/report-found-form.md`, which had drifted out of date on several points unrelated to this PR (images were already linked for found-item reports, the schema uses separate `title`/`description` fields, and the upload component was renamed to `ImageUploadGallery.tsx`).

## Test plan
- [x] `pnpm typecheck` / `pnpm lint` / `pnpm test` (foundit-ui) — all pass
- [x] `pnpm typecheck` / `pnpm lint` (backend) — all pass
- [x] `pnpm build` (foundit-ui, via pre-push hook) — succeeds
- [ ] Manually submit a claim with 1-3 photos and confirm the objects land in R2 and `item_image` rows are created with `claim_id` set

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Lost-item claims can now include up to 3 photos when submitting a claim.
  * Claim submissions now upload selected images automatically and attach them to the claim.

* **Bug Fixes**
  * Improved claim saving so text and images are submitted together more reliably.
  * Updated the claim form to better handle missing sign-in data and preserve image-related submission behavior.

* **Documentation**
  * Updated the found-item report guide to reflect the current submission flow and image support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->