### PR TITLE
Claims email notifications

### DIFF
--- a/backend/prisma/migrations/20260720171500_claim_notification_preference_email_only/migration.sql
+++ b/backend/prisma/migrations/20260720171500_claim_notification_preference_email_only/migration.sql
@@ -1,0 +1,16 @@
+-- Keep existing claim rows valid before narrowing the enum to email-only.
+UPDATE "claim"
+SET "notification_preference" = 'email'
+WHERE "notification_preference" IN ('phone', 'email_and_phone');
+
+ALTER TYPE "claim_notification_preference" RENAME TO "claim_notification_preference_old";
+
+CREATE TYPE "claim_notification_preference" AS ENUM ('email');
+
+ALTER TABLE "claim"
+ALTER COLUMN "notification_preference" DROP DEFAULT,
+ALTER COLUMN "notification_preference" TYPE "claim_notification_preference"
+USING "notification_preference"::text::"claim_notification_preference",
+ALTER COLUMN "notification_preference" SET DEFAULT 'email';
+
+DROP TYPE "claim_notification_preference_old";

--- a/backend/prisma/migrations/20260720173000_add_missing_campus/migration.sql
+++ b/backend/prisma/migrations/20260720173000_add_missing_campus/migration.sql
@@ -1,0 +1,7 @@
+INSERT INTO "campus" ("campus_id", "campus_name", "address", "retention_days")
+VALUES ('00000000-0000-0000-0000-000000000000', 'missing', NULL, 30)
+ON CONFLICT ("campus_id") DO UPDATE
+SET
+  "campus_name" = EXCLUDED."campus_name",
+  "address" = EXCLUDED."address",
+  "retention_days" = EXCLUDED."retention_days";

--- a/backend/prisma/schema.prisma
+++ b/backend/prisma/schema.prisma
@@ -76,8 +76,6 @@ enum EmailDeliveryStatus {
 
 enum ClaimNotificationPreference {
   email
-  phone
-  email_and_phone
 
   @@map("claim_notification_preference")
 }

--- a/backend/prisma/seed.ts
+++ b/backend/prisma/seed.ts
@@ -2,9 +2,25 @@ import { PrismaClient } from '@prisma/client';
 import bcrypt from 'bcryptjs';
 
 const prisma = new PrismaClient();
+const MISSING_CAMPUS_ID = '00000000-0000-0000-0000-000000000000';
 
 async function main() {
   // ── Core data (always seeded) ─────────────────────────────────────────────
+
+  await prisma.campus.upsert({
+    where: { campusId: MISSING_CAMPUS_ID },
+    update: {
+      campusName: 'missing',
+      address: null,
+      retentionDays: 30,
+    },
+    create: {
+      campusId: MISSING_CAMPUS_ID,
+      campusName: 'missing',
+      address: null,
+      retentionDays: 30,
+    },
+  });
 
   const [newnham, senecaYork] = await Promise.all([
     prisma.campus.upsert({
@@ -45,7 +61,7 @@ async function main() {
     }),
   ]);
 
-  console.log('Campuses: Newnham, Seneca@York, King, Peterborough');
+  console.log('Campuses: missing, Newnham, Seneca@York, King, Peterborough');
 
   const adminHash = await bcrypt.hash('Admin@1234', 12);
   const admin = await prisma.user.upsert({

--- a/backend/src/lib/claimEmailNotifications.ts
+++ b/backend/src/lib/claimEmailNotifications.ts
@@ -27,6 +27,7 @@ export interface StudentClaimEmailTarget {
     firstName: string;
     lastName: string;
     email: string;
+    emailNotificationOptIn: boolean;
   };
 }
 
@@ -47,8 +48,8 @@ function escapeHtml(value: string): string {
 
 function claimWantsEmail(claim: StudentClaimEmailTarget): boolean {
   return (
-    claim.notificationPreference === 'email' ||
-    claim.notificationPreference === 'email_and_phone'
+    claim.student.emailNotificationOptIn &&
+    claim.notificationPreference === 'email'
   );
 }
 

--- a/backend/src/routes/claims.ts
+++ b/backend/src/routes/claims.ts
@@ -576,6 +576,9 @@ async function notifySecurityOfClaimCancellation(
  *                 type: string
  *               itemName:
  *                 type: string
+ *               campusId:
+ *                 type: string
+ *                 format: uuid
  *               description:
  *                 type: string
  *               additionalInfo:
@@ -623,11 +626,25 @@ router.post(
         return;
       }
 
-      // Claims are campus-agnostic at submission time. Store them under the
-      // sentinel "missing" campus until campus selection is modeled explicitly.
-      const campusId = MISSING_CAMPUS_ID;
-
       const payload = req.body as CreateClaimInput;
+      // If the claim form provides a campus, honor it. Otherwise store the
+      // claim under the sentinel "missing" campus until the student chooses one.
+      const campusId = payload.campusId ?? MISSING_CAMPUS_ID;
+
+      if (payload.campusId) {
+        const campus = await prisma.campus.findUnique({
+          where: { campusId: payload.campusId },
+          select: { campusId: true },
+        });
+
+        if (!campus) {
+          res.status(404).json({
+            code: 'CAMPUS_NOT_FOUND',
+            message: 'Campus not found.',
+          });
+          return;
+        }
+      }
 
       const { claim, notification } = await prisma.$transaction(async (tx) => {
         const created = await tx.claim.create({

--- a/backend/src/routes/claims.ts
+++ b/backend/src/routes/claims.ts
@@ -37,6 +37,7 @@ import {
 import { validate, validateQuery } from '../validators/shared';
 
 const router = Router();
+const MISSING_CAMPUS_ID = '00000000-0000-0000-0000-000000000000';
 
 const claimListSelect = {
   claimId: true,
@@ -68,6 +69,7 @@ const claimListSelect = {
       firstName: true,
       lastName: true,
       email: true,
+      emailNotificationOptIn: true,
       studentNumber: true,
     },
   },
@@ -580,7 +582,7 @@ async function notifySecurityOfClaimCancellation(
  *                 type: string
  *               notificationPreference:
  *                 type: string
- *                 enum: [email, phone, email_and_phone]
+ *                 enum: [email]
  *               dateLost:
  *                 type: string
  *                 format: date
@@ -621,26 +623,9 @@ router.post(
         return;
       }
 
-      // Temporary fallback: some student accounts currently have no campusId,
-      // but Claim.campusId is still required by the database schema. Use the
-      // first configured campus so claim submission can continue until campus
-      // selection is modeled explicitly on the claim form.
-      const campusId =
-        actor.campusId ??
-        (
-          await prisma.campus.findFirst({
-            select: { campusId: true },
-            orderBy: { campusName: 'asc' },
-          })
-        )?.campusId;
-
-      if (!campusId) {
-        res.status(409).json({
-          code: 'CLAIM_CAMPUS_REQUIRED',
-          message: 'A campus must be assigned before a claim can be submitted.',
-        });
-        return;
-      }
+      // Claims are campus-agnostic at submission time. Store them under the
+      // sentinel "missing" campus until campus selection is modeled explicitly.
+      const campusId = MISSING_CAMPUS_ID;
 
       const payload = req.body as CreateClaimInput;
 

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -245,17 +245,50 @@ router.put(
   }
 );
 
-// TODO: Toggle email_notification_opt_in (students only)
 router.patch(
   '/me/notifications',
   authenticate,
   requireRole('student'),
   validate(updateNotificationSchema),
-  (_req, res) => {
-    res.status(501).json({
-      code: 'NOT_IMPLEMENTED',
-      message: 'PATCH /api/users/me/notifications not yet implemented',
-    });
+  async (req, res, next) => {
+    try {
+      const userId = req.user!.user_id;
+      const existing = await loadActiveUserProfile(userId, res);
+      if (!existing) {
+        return;
+      }
+
+      const { emailNotificationOptIn } = req.body as z.infer<
+        typeof updateNotificationSchema
+      >;
+
+      const updated = await prisma.user.update({
+        where: { userId },
+        data: { emailNotificationOptIn },
+        select: {
+          ...userProfileSelect,
+          campus: { select: { campusName: true } },
+        },
+      });
+
+      await writeAuditLog({
+        actorId: userId,
+        action: 'user_notification_preferences_updated',
+        entityType: 'user',
+        entityId: userId,
+        details: {
+          previous: {
+            emailNotificationOptIn: existing.emailNotificationOptIn,
+          },
+          updated: { emailNotificationOptIn },
+        },
+        ipAddress: req.ip,
+      });
+
+      res.status(200).json(toUserProfileDto(updated));
+    } catch (err) {
+      next(err);
+    }
   }
 );
 

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -290,39 +290,81 @@ router.patch(
   async (req, res, next) => {
     try {
       const userId = req.user!.user_id;
-      const existing = await loadActiveUserProfile(userId, res);
-      if (!existing) {
-        return;
-      }
-
       const { emailNotificationOptIn } = req.body as z.infer<
         typeof updateNotificationSchema
       >;
 
-      const updated = await prisma.user.update({
-        where: { userId },
-        data: { emailNotificationOptIn },
-        select: {
-          ...userProfileSelect,
-          campus: { select: { campusName: true } },
-        },
-      });
-
-      await writeAuditLog({
-        actorId: userId,
-        action: 'user_notification_preferences_updated',
-        entityType: 'user',
-        entityId: userId,
-        details: {
-          previous: {
-            emailNotificationOptIn: existing.emailNotificationOptIn,
+      const result = await prisma.$transaction(async (tx) => {
+        const existing = await tx.user.findUnique({
+          where: { userId },
+          select: {
+            ...userProfileSelect,
+            campus: { select: { campusName: true } },
           },
-          updated: { emailNotificationOptIn },
-        },
-        ipAddress: req.ip,
+        });
+
+        if (!existing) {
+          return {
+            updated: undefined,
+            error: {
+              status: 404,
+              body: {
+                code: 'USER_NOT_FOUND',
+                message: 'User account no longer exists.',
+              },
+            },
+          } as const;
+        }
+
+        if (!existing.isActive) {
+          return {
+            updated: undefined,
+            error: {
+              status: 403,
+              body: {
+                code: 'ACCOUNT_INACTIVE',
+                message:
+                  'Your account has been deactivated. Contact an administrator.',
+              },
+            },
+          } as const;
+        }
+
+        const updated = await tx.user.update({
+          where: { userId },
+          data: { emailNotificationOptIn },
+          select: {
+            ...userProfileSelect,
+            campus: { select: { campusName: true } },
+          },
+        });
+
+        await writeAuditLog(
+          {
+            actorId: userId,
+            action: 'user_notification_preferences_updated',
+            entityType: 'user',
+            entityId: userId,
+            details: {
+              previous: {
+                emailNotificationOptIn: existing.emailNotificationOptIn,
+              },
+              updated: { emailNotificationOptIn },
+            },
+            ipAddress: req.ip,
+          },
+          tx
+        );
+
+        return { updated, error: undefined } as const;
       });
 
-      res.status(200).json(toUserProfileDto(updated));
+      if (result.error) {
+        res.status(result.error.status).json(result.error.body);
+        return;
+      }
+
+      res.status(200).json(toUserProfileDto(result.updated));
     } catch (err) {
       next(err);
     }

--- a/backend/src/validators/claims.ts
+++ b/backend/src/validators/claims.ts
@@ -21,11 +21,7 @@ const optionalDateSchema = z.iso
   .transform((value) => new Date(`${value}T00:00:00.000Z`))
   .optional();
 
-const claimNotificationPreferenceValues = [
-  'email',
-  'phone',
-  'email_and_phone',
-] as const;
+const claimNotificationPreferenceValues = ['email'] as const;
 
 export const claimParamsSchema = z.object({
   claimId: z.uuid(),

--- a/backend/src/validators/claims.ts
+++ b/backend/src/validators/claims.ts
@@ -35,6 +35,7 @@ export const claimAndMatchParamsSchema = z.object({
 export const createClaimSchema = z.object({
   category: z.string().min(1).max(50).trim(),
   itemName: z.string().max(100).trim().optional(),
+  campusId: z.uuid().optional(),
   description: z.string().min(1).max(2000).trim(),
   additionalInfo: z.string().max(2000).trim().optional(),
   notificationPreference: z.enum(claimNotificationPreferenceValues).optional(),

--- a/backend/tests/claims.integration.test.ts
+++ b/backend/tests/claims.integration.test.ts
@@ -37,6 +37,7 @@ vi.mock('../src/db', () => ({
     },
     campus: {
       findFirst: vi.fn(),
+      findUnique: vi.fn(),
     },
     auditLog: {
       create: vi.fn().mockResolvedValue({ logId: 'log-1' }),
@@ -383,6 +384,50 @@ describe('claims routes', () => {
       where: {
         role: { in: [UserRole.security, UserRole.admin] },
         campusId: MISSING_CAMPUS_ID,
+        isActive: true,
+      },
+      select: { userId: true },
+    });
+  });
+
+  test('POST /api/claims uses the selected campus when campusId is provided', async () => {
+    const selectedCampusId = '550e8400-e29b-41d4-a716-446655440042';
+
+    mocks.authUser = { user_id: 'student-1', role: UserRole.student };
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(activeStudent);
+    vi.mocked(prisma.campus.findUnique).mockResolvedValueOnce({
+      campusId: selectedCampusId,
+    });
+
+    const tx = createClaimTx([{ userId: 'security-1' }]);
+    vi.mocked(prisma.$transaction).mockImplementationOnce(
+      async (fn: (client: unknown) => unknown) => fn(tx)
+    );
+
+    const app = createTestApp();
+
+    const res = await request(app).post('/api/claims').send({
+      campusId: selectedCampusId,
+      category: 'Electronics',
+      description: 'Lost my iPhone',
+    });
+
+    expect(res.status).toBe(201);
+    expect(prisma.campus.findUnique).toHaveBeenCalledWith({
+      where: { campusId: selectedCampusId },
+      select: { campusId: true },
+    });
+    expect(tx.claim.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          campusId: selectedCampusId,
+        }),
+      })
+    );
+    expect(tx.user.findMany).toHaveBeenCalledWith({
+      where: {
+        role: { in: [UserRole.security, UserRole.admin] },
+        campusId: selectedCampusId,
         isActive: true,
       },
       select: { userId: true },

--- a/backend/tests/claims.integration.test.ts
+++ b/backend/tests/claims.integration.test.ts
@@ -64,6 +64,8 @@ vi.mock('../src/lib/email', () => ({
 import { prisma } from '../src/db';
 import { sendNotificationEmail } from '../src/lib/email';
 
+const MISSING_CAMPUS_ID = '00000000-0000-0000-0000-000000000000';
+
 function createTestApp() {
   const app = express();
   app.use(express.json());
@@ -142,6 +144,7 @@ const claimRow = {
     firstName: 'Casey',
     lastName: 'Hsu',
     email: 'student@myseneca.ca',
+    emailNotificationOptIn: false,
     studentNumber: null,
   },
   item: null,
@@ -150,6 +153,14 @@ const claimRow = {
   verifiedBy: null,
   reviewer: null,
   verifier: null,
+};
+
+const optedInClaimRow = {
+  ...claimRow,
+  student: {
+    ...claimRow.student,
+    emailNotificationOptIn: true,
+  },
 };
 
 describe('claims routes', () => {
@@ -261,10 +272,20 @@ describe('claims routes', () => {
   });
 
   function createClaimTx(securityRecipients: { userId: string }[]) {
+    const createdClaim = {
+      ...claimRow,
+      campusId: MISSING_CAMPUS_ID,
+      campus: {
+        ...claimRow.campus,
+        campusId: MISSING_CAMPUS_ID,
+        campusName: 'missing',
+      },
+    };
+
     return {
       claim: {
         create: vi.fn().mockResolvedValue({ claimId: claimRow.claimId }),
-        findUniqueOrThrow: vi.fn().mockResolvedValue(claimRow),
+        findUniqueOrThrow: vi.fn().mockResolvedValue(createdClaim),
       },
       itemImage: {
         createMany: vi.fn(),
@@ -284,7 +305,7 @@ describe('claims routes', () => {
     };
   }
 
-  test('POST /api/claims notifies active same-campus security staff', async () => {
+  test('POST /api/claims notifies active missing-campus security staff', async () => {
     mocks.authUser = { user_id: 'student-1', role: UserRole.student };
     vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(activeStudent);
 
@@ -300,10 +321,17 @@ describe('claims routes', () => {
       .send({ category: 'Electronics', description: 'Lost my iPhone' });
 
     expect(res.status).toBe(201);
+    expect(tx.claim.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          campusId: MISSING_CAMPUS_ID,
+        }),
+      })
+    );
     expect(tx.user.findMany).toHaveBeenCalledWith({
       where: {
         role: { in: [UserRole.security, UserRole.admin] },
-        campusId: 'campus-1',
+        campusId: MISSING_CAMPUS_ID,
         isActive: true,
       },
       select: { userId: true },
@@ -324,14 +352,11 @@ describe('claims routes', () => {
     });
   });
 
-  test('POST /api/claims falls back to first campus record when student has no campusId', async () => {
+  test('POST /api/claims uses missing campus when student has no campusId', async () => {
     mocks.authUser = { user_id: 'student-1', role: UserRole.student };
     vi.mocked(prisma.user.findUnique).mockResolvedValueOnce({
       ...activeStudent,
       campusId: null,
-    });
-    vi.mocked(prisma.campus.findFirst).mockResolvedValueOnce({
-      campusId: 'campus-42',
     });
 
     const tx = createClaimTx([{ userId: 'security-1' }]);
@@ -346,14 +371,18 @@ describe('claims routes', () => {
       .send({ category: 'Electronics', description: 'Lost my iPhone' });
 
     expect(res.status).toBe(201);
-    expect(prisma.campus.findFirst).toHaveBeenCalledWith({
-      select: { campusId: true },
-      orderBy: { campusName: 'asc' },
-    });
+    expect(prisma.campus.findFirst).not.toHaveBeenCalled();
+    expect(tx.claim.create).toHaveBeenCalledWith(
+      expect.objectContaining({
+        data: expect.objectContaining({
+          campusId: MISSING_CAMPUS_ID,
+        }),
+      })
+    );
     expect(tx.user.findMany).toHaveBeenCalledWith({
       where: {
         role: { in: [UserRole.security, UserRole.admin] },
-        campusId: 'campus-42',
+        campusId: MISSING_CAMPUS_ID,
         isActive: true,
       },
       select: { userId: true },
@@ -429,10 +458,10 @@ describe('claims routes', () => {
   test('PATCH /api/claims/:claimId/status emails students when rejected', async () => {
     mocks.authUser = { user_id: 'security-1', role: UserRole.security };
     vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(activeSecurity);
-    vi.mocked(prisma.claim.findUnique).mockResolvedValueOnce(claimRow);
+    vi.mocked(prisma.claim.findUnique).mockResolvedValueOnce(optedInClaimRow);
 
     const rejectedClaim = {
-      ...claimRow,
+      ...optedInClaimRow,
       status: ClaimStatus.rejected,
       rejectionReason: 'Not enough ownership details.',
     };
@@ -496,13 +525,13 @@ describe('claims routes', () => {
     mocks.authUser = { user_id: 'security-1', role: UserRole.security };
     vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(activeSecurity);
     vi.mocked(prisma.claim.findUnique).mockResolvedValueOnce({
-      ...claimRow,
+      ...optedInClaimRow,
       itemId: '550e8400-e29b-41d4-a716-446655440010',
       status: ClaimStatus.approved,
     });
 
     const pickedUpClaim = {
-      ...claimRow,
+      ...optedInClaimRow,
       itemId: '550e8400-e29b-41d4-a716-446655440010',
       status: ClaimStatus.picked_up,
       pickedUpAt: new Date('2026-07-02'),
@@ -551,5 +580,51 @@ describe('claims routes', () => {
         text: expect.stringContaining(notification.message),
       })
     );
+  });
+
+  test('PATCH /api/claims/:claimId/status skips email when the student opted out', async () => {
+    mocks.authUser = { user_id: 'security-1', role: UserRole.security };
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(activeSecurity);
+    vi.mocked(prisma.claim.findUnique).mockResolvedValueOnce(claimRow);
+
+    const rejectedClaim = {
+      ...claimRow,
+      status: ClaimStatus.rejected,
+      rejectionReason: 'Not enough ownership details.',
+    };
+
+    const tx = {
+      claim: {
+        update: vi.fn().mockResolvedValue(rejectedClaim),
+      },
+      notification: {
+        create: vi.fn().mockResolvedValue({
+          notificationId: '550e8400-e29b-41d4-a716-446655440092',
+          type: 'claim_status_update',
+          title: 'Claim status updated: rejected',
+          message:
+            'Your claim for "iPhone 15" is now rejected. Reason: Not enough ownership details.',
+        }),
+      },
+      auditLog: {
+        create: vi.fn().mockResolvedValue({ logId: 'log-4' }),
+      },
+    };
+    vi.mocked(prisma.$transaction).mockImplementationOnce(
+      async (fn: (client: unknown) => unknown) => fn(tx)
+    );
+
+    const app = createTestApp();
+
+    const res = await request(app)
+      .patch('/api/claims/550e8400-e29b-41d4-a716-446655440000/status')
+      .send({
+        status: 'rejected',
+        rejectionReason: 'Not enough ownership details.',
+      });
+
+    expect(res.status).toBe(200);
+    expect(sendNotificationEmail).not.toHaveBeenCalled();
+    expect(prisma.notification.update).not.toHaveBeenCalled();
   });
 });

--- a/backend/tests/users.integration.test.ts
+++ b/backend/tests/users.integration.test.ts
@@ -176,14 +176,36 @@ describe('users routes', () => {
     );
   });
 
-  test('PATCH /api/users/me/notifications returns 501 because it is not implemented yet', async () => {
+  test('PATCH /api/users/me/notifications updates student email opt-in', async () => {
+    const updatedUser = {
+      ...userRow,
+      emailNotificationOptIn: false,
+    };
+
+    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(userRow);
+    vi.mocked(prisma.user.update).mockResolvedValueOnce(updatedUser);
+
     const app = createTestApp();
 
     const res = await request(app).patch('/api/users/me/notifications').send({
       emailNotificationOptIn: false,
     });
 
-    expect(res.status).toBe(501);
-    expect(res.body.code).toBe('NOT_IMPLEMENTED');
+    expect(res.status).toBe(200);
+    expect(res.body.emailNotificationOptIn).toBe(false);
+    expect(prisma.user.update).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 'student-1' },
+        data: { emailNotificationOptIn: false },
+      })
+    );
+    expect(writeAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: 'student-1',
+        action: 'user_notification_preferences_updated',
+        entityType: 'user',
+        entityId: 'student-1',
+      })
+    );
   });
 });

--- a/backend/tests/users.integration.test.ts
+++ b/backend/tests/users.integration.test.ts
@@ -36,6 +36,7 @@ vi.mock('../src/db', () => ({
       findUnique: vi.fn(),
       update: vi.fn(),
     },
+    $transaction: vi.fn(),
   },
 }));
 
@@ -199,9 +200,16 @@ describe('users routes', () => {
       ...userRow,
       emailNotificationOptIn: false,
     };
+    const tx = {
+      user: {
+        findUnique: vi.fn().mockResolvedValue(userRow),
+        update: vi.fn().mockResolvedValue(updatedUser),
+      },
+    };
 
-    vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(userRow);
-    vi.mocked(prisma.user.update).mockResolvedValueOnce(updatedUser);
+    vi.mocked(prisma.$transaction).mockImplementationOnce(
+      async (fn: (client: unknown) => unknown) => fn(tx)
+    );
 
     const app = createTestApp();
 
@@ -211,7 +219,12 @@ describe('users routes', () => {
 
     expect(res.status).toBe(200);
     expect(res.body.emailNotificationOptIn).toBe(false);
-    expect(prisma.user.update).toHaveBeenCalledWith(
+    expect(tx.user.findUnique).toHaveBeenCalledWith(
+      expect.objectContaining({
+        where: { userId: 'student-1' },
+      })
+    );
+    expect(tx.user.update).toHaveBeenCalledWith(
       expect.objectContaining({
         where: { userId: 'student-1' },
         data: { emailNotificationOptIn: false },
@@ -223,7 +236,8 @@ describe('users routes', () => {
         action: 'user_notification_preferences_updated',
         entityType: 'user',
         entityId: 'student-1',
-      })
+      }),
+      tx
     );
   });
 });

--- a/foundit-ui/hooks/useClaimItemForm.ts
+++ b/foundit-ui/hooks/useClaimItemForm.ts
@@ -25,10 +25,6 @@ const FIELD_ORDER = [
   'locationLost',
 ] as const;
 
-// What the student wants to be notified through when their claim advances.
-// Phone-based options are only selectable when the profile has a phone number.
-export type NotificationPreference = 'email' | 'phone' | 'email_and_phone';
-
 // Matches the Figma error copy: "{Field} is a required field".
 function requiredMsg(label: string): string {
   return `${label} is a required field`;
@@ -57,10 +53,6 @@ export function useClaimItemForm() {
   const [dateLost, setDateLost] = useState('');
   const [locationLost, setLocationLost] = useState('');
   const [description, setDescription] = useState('');
-  // Defaults to 'email' — students are opted in to email notifications unless
-  // they pick otherwise.
-  const [notificationPreference, setNotificationPreference] =
-    useState<NotificationPreference>('email');
   const [additionalInformation, setAdditionalInformation] = useState('');
   // Fed by the image gallery as raw Files; uploaded to R2 at submit time
   // (mirrors useReportFoundItemForm's handleImageUpload loop) and attached
@@ -164,7 +156,6 @@ export function useClaimItemForm() {
       hasDateLost: Boolean(dateLost.trim()),
       locationLostLength: trimmedLocation.length,
       descriptionLength: description.trim().length,
-      notificationPreference,
       additionalInformationLength: additionalInformation.trim().length,
       imageFileCount: imageFiles.length,
     });
@@ -194,7 +185,6 @@ export function useClaimItemForm() {
           dateLost: dateLost.trim() || undefined,
           locationLost: trimmedLocation || undefined,
           additionalInfo: additionalInformation.trim() || undefined,
-          notificationPreference,
           images: uploadedImages,
         }),
       });
@@ -238,8 +228,6 @@ export function useClaimItemForm() {
     setLocationLost,
     description,
     setDescription,
-    notificationPreference,
-    setNotificationPreference,
     additionalInformation,
     setAdditionalInformation,
     imageFiles,

--- a/foundit-ui/hooks/useProfileForm.ts
+++ b/foundit-ui/hooks/useProfileForm.ts
@@ -180,9 +180,9 @@ export function useProfileForm() {
         return;
       }
 
-      const notificationErrBody = (await notificationRes.json().catch(
-        () => null
-      )) as {
+      const notificationErrBody = (await notificationRes
+        .json()
+        .catch(() => null)) as {
         message?: string;
       } | null;
       setSaveStatus('error');

--- a/foundit-ui/hooks/useProfileForm.ts
+++ b/foundit-ui/hooks/useProfileForm.ts
@@ -118,7 +118,26 @@ export function useProfileForm() {
         }),
       });
 
-      setSaveStatus(profileRes.ok ? 'success' : 'error');
+      if (!profileRes.ok) {
+        setSaveStatus('error');
+        return;
+      }
+
+      const notificationRes = await fetch(
+        `${API_BASE}/api/users/me/notifications`,
+        {
+          method: 'PATCH',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${token}`,
+          },
+          body: JSON.stringify({
+            emailNotificationOptIn: allowEmailNotifications,
+          }),
+        }
+      );
+
+      setSaveStatus(notificationRes.ok ? 'success' : 'error');
     } catch {
       setSaveStatus('error');
     } finally {

--- a/foundit-ui/tests/hooks/useClaimItemForm.test.ts
+++ b/foundit-ui/tests/hooks/useClaimItemForm.test.ts
@@ -65,12 +65,6 @@ describe('useClaimItemForm', () => {
     expect(apiFetchMock).not.toHaveBeenCalled();
   });
 
-  it('defaults notification preference to email (opted in)', () => {
-    const { result } = renderHook(() => useClaimItemForm());
-
-    expect(result.current.notificationPreference).toBe('email');
-  });
-
   it('submits trimmed values and navigates to the confirmation screen', async () => {
     apiFetchMock.mockResolvedValueOnce({ claimId: 'claim-1' });
     const { result } = renderHook(() => useClaimItemForm());
@@ -88,7 +82,6 @@ describe('useClaimItemForm', () => {
         category: 'Electronics',
         itemName: 'MacBook Pro',
         description: 'Black backpack',
-        notificationPreference: 'email',
         images: [],
       }),
     });
@@ -125,7 +118,6 @@ describe('useClaimItemForm', () => {
         category: 'Electronics',
         itemName: 'MacBook Pro',
         description: 'Black backpack',
-        notificationPreference: 'email',
         images: [
           { imageUrl: 'reports/abc.jpg', fileType: 'jpg', fileSizeKb: 120 },
         ],

--- a/foundit-ui/types/claims.ts
+++ b/foundit-ui/types/claims.ts
@@ -5,10 +5,7 @@ export type ApiClaimStatus =
   | 'picked_up'
   | 'under_review';
 
-export type ApiClaimNotificationPreference =
-  | 'email'
-  | 'phone'
-  | 'email_and_phone';
+export type ApiClaimNotificationPreference = 'email';
 
 export interface ClaimImage {
   imageId: string;

--- a/foundit-ui/utils/claimDisplay.ts
+++ b/foundit-ui/utils/claimDisplay.ts
@@ -68,8 +68,6 @@ const notificationPreferenceLabels: Record<
   string
 > = {
   email: 'Email',
-  phone: 'Phone',
-  email_and_phone: 'Email and phone',
 };
 
 export function formatNotificationPreference(


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added authenticated updates for student email notification opt-in from the profile.
  * Claims can optionally be linked to a selected campus.
  * Claims submitted without a campus are assigned to a designated “missing” campus.

* **Updates**
  * Claim notification delivery is now email-only.
  * Claim emails are sent only when the student has opted in.
  * Profile save status now reflects success or failure of both profile and notification opt-in updates.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->