### PR TITLE
released rejected items back to item list

### DIFF
--- a/backend/src/routes/claims.ts
+++ b/backend/src/routes/claims.ts
@@ -1450,9 +1450,32 @@ router.patch(
       const { claim: updated, notification } = await prisma.$transaction(
         async (tx) => {
           let itemTransitioned = false;
+          let previousItemStatus: ItemStatus = ItemStatus.stored;
+          let nextItemStatus: ItemStatus = ItemStatus.claimed;
+
           if (status === ClaimStatus.approved && claim.itemId) {
             await reserveItemForClaim(tx, claim.itemId);
             itemTransitioned = true;
+          }
+
+          if (
+            status === ClaimStatus.rejected &&
+            claim.status === ClaimStatus.approved &&
+            claim.itemId
+          ) {
+            const releaseResult = await tx.item.updateMany({
+              where: {
+                itemId: claim.itemId,
+                status: ItemStatus.claimed,
+              },
+              data: { status: ItemStatus.stored },
+            });
+
+            if (releaseResult.count > 0) {
+              itemTransitioned = true;
+              previousItemStatus = ItemStatus.claimed;
+              nextItemStatus = ItemStatus.stored;
+            }
           }
 
           if (status === ClaimStatus.picked_up && claim.itemId) {
@@ -1553,8 +1576,8 @@ router.patch(
                 entityLabel: claimLabel,
                 outcome: 'success',
                 details: {
-                  previousStatus: ItemStatus.stored,
-                  nextStatus: ItemStatus.claimed,
+                  previousStatus: previousItemStatus,
+                  nextStatus: nextItemStatus,
                   claimId: claim.claimId,
                 },
                 ...statusContext,

--- a/backend/tests/claims.integration.test.ts
+++ b/backend/tests/claims.integration.test.ts
@@ -591,7 +591,11 @@ describe('claims routes', () => {
   test('PATCH /api/claims/:claimId/status emails students when rejected', async () => {
     mocks.authUser = { user_id: 'security-1', role: UserRole.security };
     vi.mocked(prisma.user.findUnique).mockResolvedValueOnce(activeSecurity);
-    vi.mocked(prisma.claim.findUnique).mockResolvedValueOnce(optedInClaimRow);
+    vi.mocked(prisma.claim.findUnique).mockResolvedValueOnce({
+      ...optedInClaimRow,
+      itemId: '550e8400-e29b-41d4-a716-446655440010',
+      status: ClaimStatus.approved,
+    });
 
     const rejectedClaim = {
       ...optedInClaimRow,
@@ -607,6 +611,9 @@ describe('claims routes', () => {
     };
 
     const tx = {
+      item: {
+        updateMany: vi.fn().mockResolvedValue({ count: 1 }),
+      },
       claim: {
         update: vi.fn().mockResolvedValue(rejectedClaim),
       },
@@ -631,6 +638,13 @@ describe('claims routes', () => {
       });
 
     expect(res.status).toBe(200);
+    expect(tx.item.updateMany).toHaveBeenCalledWith({
+      where: {
+        itemId: '550e8400-e29b-41d4-a716-446655440010',
+        status: ItemStatus.claimed,
+      },
+      data: { status: ItemStatus.stored },
+    });
     expect(sendNotificationEmail).toHaveBeenCalledWith(
       expect.objectContaining({
         to: 'student@myseneca.ca',
@@ -659,7 +673,7 @@ describe('claims routes', () => {
         entityId: claimRow.claimId,
         requestId: expect.any(String),
         details: expect.objectContaining({
-          previousStatus: ClaimStatus.submitted,
+          previousStatus: ClaimStatus.approved,
           nextStatus: ClaimStatus.rejected,
           reasonCategory: 'manual_rejection',
           actorRole: 'security',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Rejecting an approved claim now returns its linked item to “Stored” status when applicable.
  * Item status history now accurately records reservation and release transitions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->