### PR TITLE
 allow avatar remove to delete profile pic in R2

### DIFF
--- a/backend/src/routes/photoSessions.ts
+++ b/backend/src/routes/photoSessions.ts
@@ -96,8 +96,7 @@ async function findActiveSession(token: string) {
 async function createPresignedReportUpload(
   key: string,
   contentType: string,
-  fileSizeKb: number,
-  fileSizeBytes: number
+  fileSizeKb: number
 ) {
   const ext = contentType.split('/')[1];
 
@@ -105,12 +104,10 @@ async function createPresignedReportUpload(
     Bucket: R2_BUCKET,
     Key: key,
     ContentType: contentType,
-    ContentLength: fileSizeBytes,
   });
 
   const uploadUrl = await getSignedUrl(r2, command, {
     expiresIn: 60 * 60,
-    signableHeaders: new Set(['content-type', 'content-length']),
   });
 
   return {
@@ -247,10 +244,9 @@ router.post(
         return;
       }
 
-      const { contentType, fileSizeKb, fileSizeBytes } = req.body as {
+      const { contentType, fileSizeKb } = req.body as {
         contentType: string;
         fileSizeKb: number;
-        fileSizeBytes: number;
       };
 
       try {
@@ -280,8 +276,7 @@ router.post(
           const result = await createPresignedReportUpload(
             placeholder.imageUrl,
             contentType,
-            fileSizeKb,
-            fileSizeBytes
+            fileSizeKb
           );
           await writeAuditLogBestEffort({
             actorType: 'anonymous',

--- a/backend/src/routes/users.ts
+++ b/backend/src/routes/users.ts
@@ -1,11 +1,14 @@
 import { Router, Response } from 'express';
 import { z } from 'zod';
 import { User } from '@prisma/client';
+import { DeleteObjectCommand } from '@aws-sdk/client-s3';
 import { prisma } from '../db';
+import { r2, R2_BUCKET } from '../lib/r2';
 import authenticate from '../middleware/authenticate';
 import requireRole from '../middleware/requireRole';
 import { validate } from '../validators/shared';
 import {
+  AVATAR_KEY_PATTERN,
   replaceProfileSchema,
   updateNotificationSchema,
   updateProfilePhotoSchema,
@@ -441,8 +444,23 @@ router.patch(
         typeof updateProfilePhotoSchema
       >;
       const context = auditContextFromRequest(req);
+      const avatarToDelete =
+        profilePhotoUrl === null &&
+        existing.profilePhotoUrl &&
+        AVATAR_KEY_PATTERN.test(existing.profilePhotoUrl)
+          ? existing.profilePhotoUrl
+          : null;
 
       const updated = await prisma.$transaction(async (tx) => {
+        if (avatarToDelete) {
+          await r2.send(
+            new DeleteObjectCommand({
+              Bucket: R2_BUCKET,
+              Key: avatarToDelete,
+            })
+          );
+        }
+
         const profile = await tx.user.update({
           where: { userId },
           data: { profilePhotoUrl },

--- a/backend/tests/photoSessions.integration.test.ts
+++ b/backend/tests/photoSessions.integration.test.ts
@@ -92,6 +92,7 @@ vi.mock('../src/db', () => ({
 }));
 
 import { prisma } from '../src/db';
+import { PutObjectCommand } from '@aws-sdk/client-s3';
 import { getSignedUrl } from '@aws-sdk/s3-request-presigner';
 import { generateReportLinkToken } from '../src/utils/reportLinkToken';
 import { writeAuditLog, writeAuditLogBestEffort } from '../src/utils/auditLog';
@@ -275,6 +276,16 @@ describe('photoSessions routes', () => {
     );
     expect(res.body.fileType).toBe('png');
     expect(res.body.fileSizeKb).toBe(500);
+    expect(PutObjectCommand).toHaveBeenCalledWith({
+      Bucket: 'test-bucket',
+      Key: 'reports/550e8400-e29b-41d4-a716-446655440000.png',
+      ContentType: 'image/png',
+    });
+    expect(getSignedUrl).toHaveBeenCalledWith(
+      expect.anything(),
+      expect.anything(),
+      { expiresIn: 60 * 60 }
+    );
 
     // Anonymous walk-in upload: no actorRole, but the entity label names the
     // session (never the requester) and a summary is always generated.

--- a/backend/tests/users.integration.test.ts
+++ b/backend/tests/users.integration.test.ts
@@ -42,6 +42,11 @@ vi.mock('../src/utils/imageUrl', () => ({
   ),
 }));
 
+vi.mock('../src/lib/r2', () => ({
+  r2: { send: vi.fn() },
+  R2_BUCKET: 'test-bucket',
+}));
+
 vi.mock('../src/db', () => ({
   prisma: {
     user: {
@@ -53,6 +58,7 @@ vi.mock('../src/db', () => ({
 }));
 
 import { prisma } from '../src/db';
+import { r2 } from '../src/lib/r2';
 import { writeAuditLog } from '../src/utils/auditLog';
 import { auditSummaries } from '../src/utils/auditSummaries';
 
@@ -338,6 +344,11 @@ describe('users routes', () => {
 
       expect(res.status).toBe(200);
       expect(res.body.profilePhotoUrl).toBeNull();
+      expect(r2.send).toHaveBeenCalledWith(
+        expect.objectContaining({
+          input: { Bucket: 'test-bucket', Key: avatarKey },
+        })
+      );
       expect(writeAuditLog).toHaveBeenCalledWith(
         expect.objectContaining({
           actorRole: 'student',


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved photo uploads by removing unnecessary file-size requirements from signed upload requests.
  * Profile photo removal now also deletes the associated stored image.
  * Added safeguards to ensure only valid avatar files are deleted.

* **Tests**
  * Expanded coverage for photo upload signing and profile photo deletion behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->