### PR TITLE
Yun/student claims

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -132,7 +132,8 @@ src/
 │   └── username.ts             # Unique username generator
 ├── jobs/
 │   ├── cleanupUnverifiedUsers.ts  # Daily cron job to delete unverified accounts
-│   └── expireRetainedItems.ts     # Daily cron: stored → expired when retention ends
+│   ├── expireRetainedItems.ts     # Daily cron: stored → expired when retention ends
+│   └── expireOpenClaims.ts        # Daily cron: open claims → rejected after 35 days
 ├── routes/
 │   ├── health.ts               # GET /api/health
 │   ├── auth.ts                 # POST /api/auth/login|register (done) · refresh|logout (stub)
@@ -286,6 +287,8 @@ Allowed targets: `expired`, `disposed`. Transitions: `stored → expired|dispose
 
 A daily cron job (`expireRetainedItems`) also transitions `stored → expired` when `retentionExpiryDate` has passed, with a defensive skip for stored items that already have an approved claim. Security should use `disposed` to record physical disposal after expiry.
 
+A second daily cron (`expireOpenClaims`) auto-rejects `submitted` / `under_review` claims that are still open **35 days after submission** (`createdAt`). Suggested matches for those claims are dismissed, and the student gets a `claim_status_update` notice. Approved, picked-up, and already-rejected claims are left alone.
+
 ### Notifications
 
 | Method | Path                                        | Auth | Status | Description                                                                             |
@@ -299,8 +302,9 @@ Notifications are per-recipient rows, always scoped to the caller's JWT. They ar
 created transactionally by: claim submission and cancellation (fan-out to active
 security/admin at the claim's campus), claim status changes and match approval
 (to the student), the retention cron (auto-reject notices + per-campus
-`item_expiring`), and found-item report submission (`report_confirmation` to the
-finder). The unread-count "stats" endpoint from the original plan was folded into
+`item_expiring`), the open-claim expiry cron (auto-reject after 35 days), and
+found-item report submission (`report_confirmation` to the finder). The
+unread-count "stats" endpoint from the original plan was folded into
 `GET /api/notifications` as `unreadCount`. Student claim emails also send when
 both `emailNotificationOptIn` and claim `notificationPreference === 'email'` are set.
 

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -15,6 +15,7 @@ import adminUsersRouter from './routes/admin/users';
 import errorHandler from './middleware/errorHandler';
 import { startCleanupJob } from './jobs/cleanupUnverifiedUsers';
 import { startExpireRetainedItemsJob } from './jobs/expireRetainedItems';
+import { startExpireOpenClaimsJob } from './jobs/expireOpenClaims';
 import uploadsRouter from './routes/uploads';
 import photoSessionsRouter from './routes/photoSessions';
 import requestContext from './middleware/requestContext';
@@ -73,4 +74,5 @@ app.listen(PORT, () => {
   warnIfSemanticMatchingDegraded();
   startCleanupJob();
   startExpireRetainedItemsJob();
+  startExpireOpenClaimsJob();
 });

--- a/backend/src/jobs/expireOpenClaims.ts
+++ b/backend/src/jobs/expireOpenClaims.ts
@@ -1,0 +1,168 @@
+import cron from 'node-cron';
+import { randomUUID } from 'node:crypto';
+import { ClaimStatus, MatchStatus, NotificationType } from '@prisma/client';
+import { prisma } from '../db';
+import { writeAuditLog, writeAuditLogs } from '../utils/auditLog';
+import { createClaimStatusUpdateInput } from '../lib/notifications';
+
+/** Days after submit before an unmatched open claim is auto-rejected. */
+export const OPEN_CLAIM_EXPIRY_DAYS = 35;
+
+const AUTO_EXPIRE_REJECTION_REASON =
+  'Claim expired after 35 days with no confirmed match.';
+
+const OPEN_CLAIM_STATUSES = [
+  ClaimStatus.submitted,
+  ClaimStatus.under_review,
+] as const;
+
+function getOpenClaimExpiryCutoff(now = new Date()): Date {
+  const cutoff = new Date(now);
+  cutoff.setUTCDate(cutoff.getUTCDate() - OPEN_CLAIM_EXPIRY_DAYS);
+  return cutoff;
+}
+
+/**
+ * Auto-rejects open claims (`submitted` / `under_review`) that are still
+ * unmatched after the open-claim window. Does not touch approved, picked_up,
+ * or already-rejected claims.
+ */
+export async function expireOpenClaims(now = new Date()): Promise<number> {
+  const cutoff = getOpenClaimExpiryCutoff(now);
+  const runId = randomUUID();
+
+  const candidates = await prisma.claim.findMany({
+    where: {
+      status: { in: [...OPEN_CLAIM_STATUSES] },
+      createdAt: { lte: cutoff },
+    },
+    select: {
+      claimId: true,
+      studentId: true,
+      itemName: true,
+      itemId: true,
+      status: true,
+    },
+  });
+
+  if (candidates.length === 0) {
+    return 0;
+  }
+
+  const candidateClaimIds = candidates.map((claim) => claim.claimId);
+
+  return prisma.$transaction(async (tx) => {
+    const eligibleClaims = await tx.claim.findMany({
+      where: {
+        claimId: { in: candidateClaimIds },
+        status: { in: [...OPEN_CLAIM_STATUSES] },
+        createdAt: { lte: cutoff },
+      },
+      select: {
+        claimId: true,
+        studentId: true,
+        itemName: true,
+        itemId: true,
+        status: true,
+      },
+    });
+
+    if (eligibleClaims.length === 0) {
+      return 0;
+    }
+
+    const expiredClaims: typeof eligibleClaims = [];
+
+    for (const claim of eligibleClaims) {
+      const rejectResult = await tx.claim.updateMany({
+        where: {
+          claimId: claim.claimId,
+          status: { in: [...OPEN_CLAIM_STATUSES] },
+          createdAt: { lte: cutoff },
+        },
+        data: {
+          status: ClaimStatus.rejected,
+          rejectionReason: AUTO_EXPIRE_REJECTION_REASON,
+          reviewedAt: new Date(),
+          reviewedBy: null,
+        },
+      });
+
+      if (rejectResult.count === 0) {
+        continue;
+      }
+
+      expiredClaims.push(claim);
+
+      await tx.matchSuggestion.updateMany({
+        where: {
+          claimId: claim.claimId,
+          status: MatchStatus.suggested,
+        },
+        data: { status: MatchStatus.dismissed },
+      });
+    }
+
+    if (expiredClaims.length === 0) {
+      return 0;
+    }
+
+    await tx.notification.createMany({
+      data: expiredClaims.map((claim) =>
+        createClaimStatusUpdateInput(claim, 'rejected', {
+          reason: AUTO_EXPIRE_REJECTION_REASON,
+        })
+      ),
+    });
+
+    await writeAuditLog(
+      {
+        actorType: 'system',
+        action: 'notification_fanout_created',
+        entityType: 'notification',
+        entityId: null,
+        outcome: 'success',
+        runId,
+        details: {
+          recipientCount: expiredClaims.length,
+          sourceEntityType: 'claim',
+          notificationType: NotificationType.claim_status_update,
+        },
+      },
+      tx
+    );
+
+    await writeAuditLogs(
+      expiredClaims.map((claim) => ({
+        actorType: 'system',
+        action: 'claim_status_updated',
+        entityType: 'claim',
+        entityId: claim.claimId,
+        outcome: 'success',
+        reasonCode: 'claim_open_expired',
+        runId,
+        entityLabel: claim.itemName ?? undefined,
+        details: {
+          previousStatus: claim.status,
+          nextStatus: ClaimStatus.rejected,
+          itemId: claim.itemId,
+          reasonCategory: 'open_claim_expired',
+        },
+      })),
+      tx
+    );
+
+    return expiredClaims.length;
+  });
+}
+
+export function startExpireOpenClaimsJob() {
+  cron.schedule('0 0 * * *', async () => {
+    try {
+      const count = await expireOpenClaims();
+      console.log(`Auto-expired ${count} open claim${count === 1 ? '' : 's'}`);
+    } catch (error) {
+      console.error('Failed to auto-expire open claims', error);
+    }
+  });
+}

--- a/backend/src/routes/auth.ts
+++ b/backend/src/routes/auth.ts
@@ -360,11 +360,6 @@ router.post('/register', validate(registerSchema), async (req, res, next) => {
       data.firstName,
       data.lastName
     );
-    const securityEmails = ['rvelasco6@myseneca.ca'];
-    const role = securityEmails.includes(data.email.toLowerCase())
-      ? 'security'
-      : 'student';
-
     const verifyToken = generateVerifyToken();
     const verifyTokenHash = hashTokenForStorage(verifyToken);
     let user;
@@ -376,7 +371,7 @@ router.post('/register', validate(registerSchema), async (req, res, next) => {
             email: normalizedEmail,
             passwordHash,
             username,
-            role,
+            role: 'student',
             firstName: data.firstName,
             lastName: data.lastName,
             // campusId is optional at registration — null until assigned by an admin

--- a/foundit-ui/app/profile/page.tsx
+++ b/foundit-ui/app/profile/page.tsx
@@ -3,7 +3,10 @@
 import Navbar from '@/components/Navbar';
 import Footer from '@/components/Footer';
 import NotificationFeed from '@/components/NotificationFeed';
-import { NotificationsProvider } from '@/components/NotificationsProvider';
+import {
+  NotificationsProvider,
+  useNotificationsBadge,
+} from '@/components/NotificationsProvider';
 import { FixedPageBackground } from '@/components/PageBackground';
 import TextInput from '@/components/TextInput';
 import { useProfileForm } from '@/hooks/useProfileForm';
@@ -13,6 +16,7 @@ import {
   Box,
   Button,
   Flex,
+  HStack,
   Image,
   Spinner,
   Stack,
@@ -42,6 +46,8 @@ function ProfileSettingsContent() {
   const displayName = useLoggedInDisplayName();
   const activeTab: ActiveTab =
     searchParams.get('tab') === 'notifications' ? 'notifications' : 'profile';
+  const notificationsBadge = useNotificationsBadge();
+  const unreadCount = notificationsBadge?.unreadCount ?? 0;
 
   const {
     fullName,
@@ -70,343 +76,361 @@ function ProfileSettingsContent() {
   const photoInputRef = useRef<HTMLInputElement>(null);
 
   return (
-    // Provider links the navbar bell and the notifications tab, so marking
-    // cards read updates the badge without a navigation.
-    <NotificationsProvider>
+    // Provider wraps this page (see ProfileSettingsPage) so the navbar bell
+    // and the notifications tab share unread count without a navigation.
+    <Box minH="100vh" display="flex" flexDirection="column" position="relative">
+      <FixedPageBackground />
+
       <Box
+        position="relative"
+        zIndex={1}
         minH="100vh"
         display="flex"
         flexDirection="column"
-        position="relative"
       >
-        <FixedPageBackground />
+        <Navbar
+          variant={navVariant}
+          userName={displayName}
+          activePath="/profile"
+        />
 
         <Box
-          position="relative"
-          zIndex={1}
-          minH="100vh"
+          flex={1}
           display="flex"
-          flexDirection="column"
+          alignItems="flex-start"
+          justifyContent="center"
+          px={{ base: 4, md: 6 }}
+          py={{ base: 6, md: 10 }}
         >
-          <Navbar
-            variant={navVariant}
-            userName={displayName}
-            activePath="/profile"
-          />
-
-          <Box
-            flex={1}
-            display="flex"
-            alignItems="flex-start"
-            justifyContent="center"
-            px={{ base: 4, md: 6 }}
-            py={{ base: 6, md: 10 }}
+          <Flex
+            direction={{ base: 'column', md: 'row' }}
+            gap={{ base: 4, md: 7 }}
+            maxW="1000px"
+            w="full"
+            align="flex-start"
+            minW={0}
           >
-            <Flex
-              direction={{ base: 'column', md: 'row' }}
-              gap={{ base: 4, md: 7 }}
-              maxW="1000px"
-              w="full"
-              align="flex-start"
-              minW={0}
+            {/* Left: profile side menu */}
+            <Stack
+              bg="white"
+              rounded="md"
+              shadow="md"
+              w={{ base: 'full', md: '240px' }}
+              flexShrink={0}
+              gap={0}
+              overflow="hidden"
+              p={{ base: 2, md: 4 }}
             >
-              {/* Left: profile side menu */}
-              <Stack
-                bg="white"
+              <Box
+                px={{ base: 3, md: 4 }}
+                py={3}
                 rounded="md"
-                shadow="md"
-                w={{ base: 'full', md: '240px' }}
-                flexShrink={0}
-                gap={0}
-                overflow="hidden"
-                p={{ base: 2, md: 4 }}
+                cursor="pointer"
+                bg={activeTab === 'profile' ? 'blue.50' : 'transparent'}
+                _hover={{
+                  bg: activeTab === 'profile' ? 'blue.50' : 'gray.50',
+                }}
+                onClick={() => router.push('/profile')}
               >
-                <Box
-                  px={{ base: 3, md: 4 }}
-                  py={3}
-                  rounded="md"
-                  cursor="pointer"
-                  bg={activeTab === 'profile' ? 'blue.500' : 'transparent'}
-                  _hover={{
-                    bg: activeTab === 'profile' ? 'blue.500' : 'gray.50',
-                  }}
-                  onClick={() => router.push('/profile')}
+                <Text
+                  color={activeTab === 'profile' ? 'blue.700' : 'gray.700'}
+                  fontWeight="medium"
+                  fontSize="sm"
                 >
+                  Profile
+                </Text>
+              </Box>
+              <Box
+                px={{ base: 3, md: 4 }}
+                py={3}
+                cursor="pointer"
+                rounded="md"
+                bg={activeTab === 'notifications' ? 'blue.50' : 'transparent'}
+                _hover={{
+                  bg: activeTab === 'notifications' ? 'blue.50' : 'gray.50',
+                }}
+                onClick={() => router.push('/profile?tab=notifications')}
+              >
+                <HStack justify="space-between" gap={3}>
                   <Text
-                    color={activeTab === 'profile' ? 'white' : 'gray.700'}
-                    fontWeight="medium"
-                    fontSize="sm"
-                  >
-                    Profile
-                  </Text>
-                </Box>
-                <Box
-                  px={{ base: 3, md: 4 }}
-                  py={3}
-                  cursor="pointer"
-                  rounded="md"
-                  bg={
-                    activeTab === 'notifications' ? 'blue.500' : 'transparent'
-                  }
-                  _hover={{
-                    bg: activeTab === 'notifications' ? 'blue.500' : 'gray.50',
-                  }}
-                  onClick={() => router.push('/profile?tab=notifications')}
-                >
-                  <Text
-                    color={activeTab === 'notifications' ? 'white' : 'gray.700'}
+                    color={
+                      activeTab === 'notifications' ? 'blue.700' : 'gray.700'
+                    }
                     fontWeight="medium"
                     fontSize="sm"
                   >
                     Notifications
                   </Text>
-                </Box>
-                <Box
-                  px={{ base: 3, md: 4 }}
-                  py={3}
-                  cursor="pointer"
-                  rounded="md"
-                  _hover={{ bg: 'red.50' }}
-                  onClick={() => router.push('/login')}
-                >
-                  <Text color="red.600" fontWeight="medium" fontSize="sm">
-                    Sign out
-                  </Text>
-                </Box>
-              </Stack>
-
-              {/* Right panel — switches between Profile and Notifications */}
-              <Stack
-                bg="white"
-                rounded="md"
-                shadow="md"
-                flex={1}
-                w={{ base: 'full', md: 'auto' }}
-                minW={0}
-                maxW={{ base: 'full', md: '720px' }}
-                p={{ base: 5, md: 8 }}
-                gap={6}
-              >
-                {activeTab === 'profile' ? (
-                  <>
-                    <Text
-                      fontSize={{ base: 'xl', md: '2xl' }}
+                  {unreadCount > 0 ? (
+                    <Box
+                      as="span"
+                      display="inline-flex"
+                      alignItems="center"
+                      justifyContent="center"
+                      minW="22px"
+                      h="18px"
+                      px={1.5}
+                      rounded="full"
+                      bg="red.600"
+                      color="white"
+                      fontSize="10px"
                       fontWeight="bold"
-                      color="gray.900"
+                      flexShrink={0}
+                      lineHeight="1"
+                      aria-label={`${unreadCount} unread`}
                     >
-                      Profile Settings
-                    </Text>
+                      {unreadCount}
+                    </Box>
+                  ) : null}
+                </HStack>
+              </Box>
+              <Box
+                px={{ base: 3, md: 4 }}
+                py={3}
+                cursor="pointer"
+                rounded="md"
+                _hover={{ bg: 'red.50' }}
+                onClick={() => router.push('/login')}
+              >
+                <Text color="red.600" fontWeight="medium" fontSize="sm">
+                  Sign out
+                </Text>
+              </Box>
+            </Stack>
 
-                    {isLoading ? (
-                      <Flex align="center" justify="center" py={10}>
-                        <Spinner size="lg" color="blue.500" />
-                      </Flex>
-                    ) : (
-                      <>
-                        {/* Avatar + change photo — the photo saves on
+            {/* Right panel — switches between Profile and Notifications */}
+            <Stack
+              bg="white"
+              rounded="md"
+              shadow="md"
+              flex={1}
+              w={{ base: 'full', md: 'auto' }}
+              minW={0}
+              maxW={{ base: 'full', md: '720px' }}
+              p={{ base: 5, md: 8 }}
+              gap={6}
+            >
+              {activeTab === 'profile' ? (
+                <>
+                  <Text
+                    fontSize={{ base: 'xl', md: '2xl' }}
+                    fontWeight="bold"
+                    color="gray.900"
+                  >
+                    Profile Settings
+                  </Text>
+
+                  {isLoading ? (
+                    <Flex align="center" justify="center" py={10}>
+                      <Spinner size="lg" color="blue.500" />
+                    </Flex>
+                  ) : (
+                    <>
+                      {/* Avatar + change photo — the photo saves on
                             selection, independently of the Save button. */}
-                        <Stack gap={2}>
-                          <Flex gap={4} align="center" wrap="wrap">
-                            {photoUrl ? (
-                              <Image
-                                src={photoUrl}
-                                alt=""
-                                w="80px"
-                                h="80px"
-                                rounded="full"
-                                objectFit="cover"
-                                flexShrink={0}
-                              />
-                            ) : (
-                              <Flex
-                                w="80px"
-                                h="80px"
-                                rounded="full"
-                                bg="blue.500"
-                                align="center"
-                                justify="center"
-                                flexShrink={0}
-                              >
-                                <Text
-                                  color="white"
-                                  fontSize="2xl"
-                                  fontWeight="bold"
-                                >
-                                  {initials || '?'}
-                                </Text>
-                              </Flex>
-                            )}
-
-                            <input
-                              ref={photoInputRef}
-                              type="file"
-                              accept="image/jpeg,image/png,image/webp"
-                              hidden
-                              data-testid="profile-photo-input"
-                              onChange={(e) => {
-                                const file = e.target.files?.[0];
-                                // Reset first so re-picking the same file
-                                // still fires a change event.
-                                e.target.value = '';
-                                if (file) handlePhotoSelected(file);
-                              }}
+                      <Stack gap={2}>
+                        <Flex gap={4} align="center" wrap="wrap">
+                          {photoUrl ? (
+                            <Image
+                              src={photoUrl}
+                              alt=""
+                              w="80px"
+                              h="80px"
+                              rounded="full"
+                              objectFit="cover"
+                              flexShrink={0}
                             />
-                            <Button
-                              variant="outline"
-                              size="sm"
-                              borderColor="gray.300"
-                              loading={photoStatus === 'uploading'}
-                              loadingText="Uploading..."
-                              onClick={() => photoInputRef.current?.click()}
+                          ) : (
+                            <Flex
+                              w="80px"
+                              h="80px"
+                              rounded="full"
+                              bg="blue.500"
+                              align="center"
+                              justify="center"
+                              flexShrink={0}
                             >
-                              Change Photo
-                            </Button>
-
-                            {photoUrl && (
-                              <Button
-                                variant="ghost"
-                                size="sm"
-                                color="red.600"
-                                disabled={photoStatus === 'uploading'}
-                                onClick={handlePhotoRemove}
+                              <Text
+                                color="white"
+                                fontSize="2xl"
+                                fontWeight="bold"
                               >
-                                Remove
-                              </Button>
-                            )}
-                          </Flex>
-
-                          {photoError && (
-                            <Text
-                              fontSize="sm"
-                              color="fg.error"
-                              fontWeight="medium"
-                            >
-                              {photoError}
-                            </Text>
-                          )}
-                        </Stack>
-
-                        {/* Form fields */}
-                        <Stack gap={5} w="full" minW={0}>
-                          <TextInput
-                            id="fullName"
-                            label="Full Name"
-                            value={fullName}
-                            width="full"
-                            disabled
-                            readOnly
-                          />
-
-                          <TextInput
-                            id="email"
-                            label="Email Address"
-                            type="email"
-                            autoComplete="email"
-                            value={email}
-                            width="full"
-                            disabled
-                            readOnly
-                          />
-
-                          {navVariant === 'student' && (
-                            <TextInput
-                              id="studentId"
-                              label="Student ID"
-                              value={studentId}
-                              width="full"
-                              inputMode="numeric"
-                              autoComplete="off"
-                              error={studentIdError}
-                              onChange={(e) => {
-                                setStudentId(e.target.value);
-                                setStudentIdError('');
-                              }}
-                            />
+                                {initials || '?'}
+                              </Text>
+                            </Flex>
                           )}
 
-                          <Flex gap={4} align="center" wrap="wrap">
-                            <Text fontSize="sm" color="gray.700">
-                              Allow email notifications
-                            </Text>
-                            <Switch.Root
-                              colorPalette="blue"
-                              checked={allowEmailNotifications}
-                              onCheckedChange={(e: { checked: boolean }) =>
-                                setAllowEmailNotifications(e.checked)
-                              }
-                            >
-                              <Switch.HiddenInput />
-                              <Switch.Control>
-                                <Switch.Thumb />
-                              </Switch.Control>
-                            </Switch.Root>
-                          </Flex>
-                        </Stack>
-
-                        {/* Save row */}
-                        <Flex
-                          gap={4}
-                          align={{ base: 'stretch', sm: 'center' }}
-                          direction={{ base: 'column', sm: 'row' }}
-                        >
+                          <input
+                            ref={photoInputRef}
+                            type="file"
+                            accept="image/jpeg,image/png,image/webp"
+                            hidden
+                            data-testid="profile-photo-input"
+                            onChange={(e) => {
+                              const file = e.target.files?.[0];
+                              // Reset first so re-picking the same file
+                              // still fires a change event.
+                              e.target.value = '';
+                              if (file) handlePhotoSelected(file);
+                            }}
+                          />
                           <Button
-                            colorPalette="blue"
-                            w={{ base: 'full', sm: '157px' }}
-                            h="40px"
-                            rounded="md"
-                            fontSize="md"
-                            loading={isSaving}
-                            loadingText="Saving..."
-                            onClick={() =>
-                              handleSave({
-                                includeStudentId: navVariant === 'student',
-                              })
-                            }
+                            variant="outline"
+                            size="sm"
+                            borderColor="gray.300"
+                            loading={photoStatus === 'uploading'}
+                            loadingText="Uploading..."
+                            onClick={() => photoInputRef.current?.click()}
                           >
-                            Save
+                            Change Photo
                           </Button>
 
-                          {saveStatus === 'success' && (
-                            <Text
-                              fontSize="sm"
-                              color="green.600"
-                              fontWeight="medium"
-                            >
-                              Changes saved.
-                            </Text>
-                          )}
-                          {saveStatus === 'error' && (
-                            <Text
-                              fontSize="sm"
+                          {photoUrl && (
+                            <Button
+                              variant="ghost"
+                              size="sm"
                               color="red.600"
-                              fontWeight="medium"
+                              disabled={photoStatus === 'uploading'}
+                              onClick={handlePhotoRemove}
                             >
-                              {saveErrorMessage ||
-                                'Save failed. Please try again.'}
-                            </Text>
+                              Remove
+                            </Button>
                           )}
                         </Flex>
-                      </>
-                    )}
-                  </>
-                ) : (
-                  <NotificationFeed />
-                )}
-              </Stack>
-            </Flex>
-          </Box>
 
-          <Footer />
+                        {photoError && (
+                          <Text
+                            fontSize="sm"
+                            color="fg.error"
+                            fontWeight="medium"
+                          >
+                            {photoError}
+                          </Text>
+                        )}
+                      </Stack>
+
+                      {/* Form fields */}
+                      <Stack gap={5} w="full" minW={0}>
+                        <TextInput
+                          id="fullName"
+                          label="Full Name"
+                          value={fullName}
+                          width="full"
+                          disabled
+                          readOnly
+                        />
+
+                        <TextInput
+                          id="email"
+                          label="Email Address"
+                          type="email"
+                          autoComplete="email"
+                          value={email}
+                          width="full"
+                          disabled
+                          readOnly
+                        />
+
+                        {navVariant === 'student' && (
+                          <TextInput
+                            id="studentId"
+                            label="Student ID"
+                            value={studentId}
+                            width="full"
+                            inputMode="numeric"
+                            autoComplete="off"
+                            error={studentIdError}
+                            onChange={(e) => {
+                              setStudentId(e.target.value);
+                              setStudentIdError('');
+                            }}
+                          />
+                        )}
+
+                        <Flex gap={4} align="center" wrap="wrap">
+                          <Text fontSize="sm" color="gray.700">
+                            Allow email notifications
+                          </Text>
+                          <Switch.Root
+                            colorPalette="blue"
+                            checked={allowEmailNotifications}
+                            onCheckedChange={(e: { checked: boolean }) =>
+                              setAllowEmailNotifications(e.checked)
+                            }
+                          >
+                            <Switch.HiddenInput />
+                            <Switch.Control>
+                              <Switch.Thumb />
+                            </Switch.Control>
+                          </Switch.Root>
+                        </Flex>
+                      </Stack>
+
+                      {/* Save row */}
+                      <Flex
+                        gap={4}
+                        align={{ base: 'stretch', sm: 'center' }}
+                        direction={{ base: 'column', sm: 'row' }}
+                      >
+                        <Button
+                          colorPalette="blue"
+                          w={{ base: 'full', sm: '157px' }}
+                          h="40px"
+                          rounded="md"
+                          fontSize="md"
+                          loading={isSaving}
+                          loadingText="Saving..."
+                          onClick={() =>
+                            handleSave({
+                              includeStudentId: navVariant === 'student',
+                            })
+                          }
+                        >
+                          Save
+                        </Button>
+
+                        {saveStatus === 'success' && (
+                          <Text
+                            fontSize="sm"
+                            color="green.600"
+                            fontWeight="medium"
+                          >
+                            Changes saved.
+                          </Text>
+                        )}
+                        {saveStatus === 'error' && (
+                          <Text
+                            fontSize="sm"
+                            color="red.600"
+                            fontWeight="medium"
+                          >
+                            {saveErrorMessage ||
+                              'Save failed. Please try again.'}
+                          </Text>
+                        )}
+                      </Flex>
+                    </>
+                  )}
+                </>
+              ) : (
+                <NotificationFeed />
+              )}
+            </Stack>
+          </Flex>
         </Box>
+
+        <Footer />
       </Box>
-    </NotificationsProvider>
+    </Box>
   );
 }
 
 export default function ProfileSettingsPage() {
   return (
-    <Suspense fallback={null}>
-      <ProfileSettingsContent />
-    </Suspense>
+    <NotificationsProvider>
+      <Suspense fallback={null}>
+        <ProfileSettingsContent />
+      </Suspense>
+    </NotificationsProvider>
   );
 }

--- a/foundit-ui/app/student/my-claims/page.tsx
+++ b/foundit-ui/app/student/my-claims/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRouter, useSearchParams } from 'next/navigation';
 import {
   Box,
   Flex,
@@ -31,6 +31,8 @@ const CLAIMS_PER_PAGE = 10;
 
 export default function StudentMyClaimsPage() {
   const router = useRouter();
+  const searchParams = useSearchParams();
+  const claimIdFromQuery = searchParams.get('claimId');
   const isLoggedIn = !!getAccessToken();
   const [isNavigatingToClaim, setIsNavigatingToClaim] = useState(false);
 
@@ -44,13 +46,38 @@ export default function StudentMyClaimsPage() {
     useState<SecurityClaimListItem | null>(null);
   const [isDetailOpen, setIsDetailOpen] = useState(false);
 
+  // Deep link from notifications: /student/my-claims?claimId=<uuid>
+  const claimFromQuery = useMemo(() => {
+    if (loading || !claimIdFromQuery) {
+      return null;
+    }
+    return claims.find((claim) => claim.claimId === claimIdFromQuery) ?? null;
+  }, [loading, claimIdFromQuery, claims]);
+
+  const detailClaim = selectedClaim ?? claimFromQuery;
+  const detailOpen = isDetailOpen || claimFromQuery !== null;
+
   function openClaimDetail(claim: SecurityClaimListItem) {
     setSelectedClaim(claim);
     setIsDetailOpen(true);
   }
 
+  function clearClaimIdQuery() {
+    const params = new URLSearchParams(searchParams.toString());
+    if (!params.has('claimId')) {
+      return;
+    }
+    params.delete('claimId');
+    const query = params.toString();
+    router.replace(
+      query ? `/student/my-claims?${query}` : '/student/my-claims'
+    );
+  }
+
   function closeClaimDetail() {
     setIsDetailOpen(false);
+    setSelectedClaim(null);
+    clearClaimIdQuery();
   }
 
   useEffect(() => {
@@ -417,8 +444,8 @@ export default function StudentMyClaimsPage() {
         </Stack>
 
         <ClaimDetailModal
-          claim={selectedClaim}
-          isOpen={isDetailOpen}
+          claim={detailClaim}
+          isOpen={detailOpen}
           onClose={closeClaimDetail}
           onCancelled={(claimId) => {
             setClaims((prev) => prev.filter((c) => c.claimId !== claimId));

--- a/foundit-ui/app/student/my-claims/page.tsx
+++ b/foundit-ui/app/student/my-claims/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { Suspense, useEffect, useMemo, useState } from 'react';
 import { useRouter, useSearchParams } from 'next/navigation';
 import {
   Box,
@@ -30,6 +30,14 @@ const Select = chakra('select');
 const CLAIMS_PER_PAGE = 10;
 
 export default function StudentMyClaimsPage() {
+  return (
+    <Suspense fallback={null}>
+      <StudentMyClaimsContent />
+    </Suspense>
+  );
+}
+
+function StudentMyClaimsContent() {
   const router = useRouter();
   const searchParams = useSearchParams();
   const claimIdFromQuery = searchParams.get('claimId');

--- a/foundit-ui/components/NotificationCard.tsx
+++ b/foundit-ui/components/NotificationCard.tsx
@@ -1,15 +1,6 @@
-import {
-  Box,
-  Checkmark,
-  Circle,
-  Flex,
-  HStack,
-  IconButton,
-  Text,
-  VStack,
-} from '@chakra-ui/react';
+import { Box, Flex, HStack, IconButton, Text, VStack } from '@chakra-ui/react';
 import type { KeyboardEvent, MouseEvent } from 'react';
-import { LuX } from 'react-icons/lu';
+import { LuMail, LuMailOpen, LuX } from 'react-icons/lu';
 import { getRelativeTime } from '@/utils/relativeDate';
 
 interface NotificationCardProps {
@@ -17,10 +8,12 @@ interface NotificationCardProps {
   message: string;
   isRead?: boolean;
   createdAt: string;
-  /** Fires when the card body is clicked — used to mark the notification read. */
+  /** Fires when the card is clicked — mark read (+ navigate in the feed). */
   onClick?: () => void;
-  /** Fires when the status circle is clicked — toggles read ⇄ unread. */
-  onToggleRead?: () => void;
+  /** Mark as read when currently unread. */
+  onMarkRead?: () => void;
+  /** Mark as unread when currently read. */
+  onMarkUnread?: () => void;
   /** Fires when the dismiss (×) control is clicked. */
   onDismiss?: () => void;
 }
@@ -31,7 +24,8 @@ export default function NotificationCard({
   isRead = false,
   createdAt,
   onClick,
-  onToggleRead,
+  onMarkRead,
+  onMarkUnread,
   onDismiss,
 }: NotificationCardProps) {
   const handleCardKeyDown = (event: KeyboardEvent) => {
@@ -47,82 +41,89 @@ export default function NotificationCard({
     onClick?.();
   };
 
-  const handleToggleClick = (event: MouseEvent) => {
-    event.stopPropagation();
-    onToggleRead?.();
-  };
-
   const handleDismissClick = (event: MouseEvent) => {
     event.stopPropagation();
     onDismiss?.();
   };
 
-  const statusCircle = isRead ? (
-    <Circle size="18px" borderWidth="2px" borderColor="gray.500">
-      <Checkmark checked size="sm" variant="plain" color="gray.500" />
-    </Circle>
-  ) : (
-    <Circle size="18px" borderWidth="2px" borderColor="black" bg="white" />
-  );
+  const handleToggleReadClick = (event: MouseEvent) => {
+    event.stopPropagation();
+    if (isRead) {
+      onMarkUnread?.();
+    } else {
+      onMarkRead?.();
+    }
+  };
+
+  const canToggleRead = isRead ? Boolean(onMarkUnread) : Boolean(onMarkRead);
 
   return (
     <Flex
       w="full"
       bg="white"
+      borderRadius="md"
       borderWidth="1px"
       borderColor="gray.200"
-      boxShadow="sm"
-      borderRadius="sm"
       overflow="hidden"
+      align="stretch"
       role={onClick ? 'button' : undefined}
       tabIndex={onClick ? 0 : undefined}
       cursor={onClick ? 'pointer' : undefined}
-      _hover={onClick ? { bg: 'gray.50' } : undefined}
+      transition="border-color 0.15s ease, background-color 0.15s ease"
+      _hover={
+        onClick
+          ? {
+              borderColor: 'gray.300',
+              bg: 'gray.50',
+            }
+          : undefined
+      }
       onClick={onClick ? handleCardClick : undefined}
       onKeyDown={handleCardKeyDown}
     >
-      <Box w="4px" bg={isRead ? 'transparent' : 'blue.500'} flexShrink={0} />
-      <HStack w="full" px={6} py={4} gap={3} align="center" minW={0}>
-        {onToggleRead ? (
-          <Box
-            as="button"
+      <Box
+        w="4px"
+        bg={isRead ? 'transparent' : 'blue.500'}
+        flexShrink={0}
+        aria-hidden
+      />
+      <HStack w="full" px={4} py={3} gap={3} align="flex-start" minW={0}>
+        {canToggleRead ? (
+          <IconButton
+            type="button"
             data-notification-action
             aria-label={isRead ? 'Mark as unread' : 'Mark as read'}
-            cursor="pointer"
+            variant="ghost"
+            size="xs"
+            color={isRead ? 'gray.400' : 'blue.500'}
             flexShrink={0}
-            onClick={handleToggleClick}
+            mt={0.5}
+            _hover={{ color: 'gray.600', bg: 'gray.100' }}
+            onClick={handleToggleReadClick}
             onKeyDown={(event) => event.stopPropagation()}
           >
-            {statusCircle}
-          </Box>
-        ) : (
-          <Box flexShrink={0}>{statusCircle}</Box>
-        )}
+            {isRead ? <LuMailOpen size={16} /> : <LuMail size={16} />}
+          </IconButton>
+        ) : null}
 
-        <VStack align="start" gap={1} flex={1} minW={0}>
+        <VStack align="start" gap={0.5} flex={1} minW={0}>
           <Text
             fontSize="sm"
             fontWeight={isRead ? 'medium' : 'semibold'}
             color={isRead ? 'gray.700' : 'fg'}
+            lineClamp={1}
           >
             {title}
           </Text>
 
-          <Text fontSize="sm" color="gray.600">
+          <Text fontSize="sm" color="fg.muted" lineClamp={2}>
             {message}
           </Text>
-        </VStack>
 
-        <Text
-          fontSize="xs"
-          color="gray.500"
-          whiteSpace="nowrap"
-          flexShrink={0}
-          alignSelf="flex-start"
-          pt={0.5}
-        >
-          {getRelativeTime(createdAt)}
-        </Text>
+          <Text fontSize="xs" color="gray.400" pt={0.5}>
+            {getRelativeTime(createdAt)}
+          </Text>
+        </VStack>
 
         {onDismiss ? (
           <IconButton
@@ -131,8 +132,9 @@ export default function NotificationCard({
             aria-label={`Dismiss ${title}`}
             variant="ghost"
             size="xs"
-            color="gray.500"
+            color="gray.400"
             flexShrink={0}
+            _hover={{ color: 'red.500', bg: 'red.50' }}
             onClick={handleDismissClick}
             onKeyDown={(event) => event.stopPropagation()}
           >

--- a/foundit-ui/components/NotificationFeed.tsx
+++ b/foundit-ui/components/NotificationFeed.tsx
@@ -5,20 +5,28 @@
  *
  * Students see it in the profile page's Notifications tab; security staff
  * reach the same tab via the navbar bell. Data comes from
- * GET /api/notifications via the useNotifications hook; clicking a card marks
- * it read, the status circle toggles read ⇄ unread, and the × control dismisses
- * a single notification. "Unread" filters server-side (?unreadOnly=true).
+ * GET /api/notifications via the useNotifications hook.
+ *
+ * Card click optimistically marks read (fire-and-forget) then navigates when
+ * a claim/item href exists. Mail toggle marks read/unread. Dismiss uses ×.
+ * All | Unread filters server-side (?unreadOnly=true). Under Unread, cards that
+ * become read stay rendered until the filter changes or the list reloads.
  * Pages load 10 at a time with Load more.
  */
 
 import { Flex, HStack, Spinner, Stack, Text } from '@chakra-ui/react';
+import { useRouter } from 'next/navigation';
 import { useState } from 'react';
 import NotificationCard from '@/components/NotificationCard';
 import Button from '@/components/ui/Button';
 import { useNotifications } from '@/hooks/useNotifications';
+import { getSessionRole } from '@/utils/auth';
+import { getNotificationHref } from '@/utils/notificationHref';
 
 export default function NotificationFeed() {
+  const router = useRouter();
   const [showUnreadOnly, setShowUnreadOnly] = useState(false);
+  const role = getSessionRole();
   const {
     notifications,
     unreadCount,
@@ -44,6 +52,14 @@ export default function NotificationFeed() {
     }
   };
 
+  const openNotification = (notificationId: string, href: string | null) => {
+    // Fire-and-forget so navigation is not blocked on the PATCH.
+    void markRead(notificationId);
+    if (href) {
+      router.push(href);
+    }
+  };
+
   return (
     <Stack gap={4} w="full" minW={0}>
       <Text
@@ -54,31 +70,36 @@ export default function NotificationFeed() {
         Notifications
       </Text>
 
-      <Flex align="center" justify="flex-end" gap={4} flexWrap="wrap">
-        <HStack gap={4}>
-          <Text
-            as="button"
-            fontSize={{ base: 'sm', md: 'md' }}
-            fontWeight="medium"
-            color={showUnreadOnly ? 'blue.500' : 'gray.600'}
-            textDecoration={showUnreadOnly ? 'underline' : 'none'}
-            cursor="pointer"
+      <Flex align="center" justify="space-between" gap={4} flexWrap="wrap">
+        <HStack gap={2} role="group" aria-label="Notification filter">
+          <Button
+            size="xs"
+            variant={!showUnreadOnly ? 'outline' : 'muted'}
+            aria-pressed={!showUnreadOnly}
+            onClick={() => setShowUnreadOnly(false)}
+          >
+            All
+          </Button>
+          <Button
+            size="xs"
+            variant={showUnreadOnly ? 'outline' : 'muted'}
             aria-pressed={showUnreadOnly}
-            onClick={() => setShowUnreadOnly((prev) => !prev)}
+            onClick={() => setShowUnreadOnly(true)}
           >
-            Unread ( {unreadCount} )
-          </Text>
-          <Text
-            as="button"
-            fontSize={{ base: 'sm', md: 'md' }}
-            fontWeight="medium"
-            color="blue.500"
-            cursor="pointer"
-            onClick={markAllRead}
-          >
-            Mark all as read
-          </Text>
+            Unread {unreadCount}
+          </Button>
         </HStack>
+
+        <Text
+          as="button"
+          fontSize="sm"
+          fontWeight="medium"
+          color="blue.500"
+          cursor="pointer"
+          onClick={markAllRead}
+        >
+          Mark all as read
+        </Text>
       </Flex>
 
       {dismissError ? (
@@ -102,26 +123,30 @@ export default function NotificationFeed() {
             : "You're all caught up — no notifications yet."}
         </Text>
       ) : (
-        <Stack gap={2}>
-          {notifications.map((notification) => (
-            <NotificationCard
-              key={notification.notificationId}
-              title={notification.title}
-              message={notification.message}
-              isRead={notification.isRead}
-              createdAt={notification.createdAt}
-              onClick={() => markRead(notification.notificationId)}
-              onToggleRead={() =>
-                notification.isRead
-                  ? markUnread(notification.notificationId)
-                  : markRead(notification.notificationId)
-              }
-              onDismiss={() => void dismissOne(notification.notificationId)}
-            />
-          ))}
+        <Stack gap={3}>
+          {notifications.map((notification) => {
+            const href = getNotificationHref(notification, role);
+            return (
+              <NotificationCard
+                key={notification.notificationId}
+                title={notification.title}
+                message={notification.message}
+                isRead={notification.isRead}
+                createdAt={notification.createdAt}
+                onClick={() =>
+                  openNotification(notification.notificationId, href)
+                }
+                onMarkRead={() => void markRead(notification.notificationId)}
+                onMarkUnread={() =>
+                  void markUnread(notification.notificationId)
+                }
+                onDismiss={() => void dismissOne(notification.notificationId)}
+              />
+            );
+          })}
 
           {nextCursor ? (
-            <Flex justify="center">
+            <Flex justify="center" pt={1}>
               <Button
                 variant="outline"
                 size="sm"

--- a/foundit-ui/components/claims/ClaimPickupNoticeCard.tsx
+++ b/foundit-ui/components/claims/ClaimPickupNoticeCard.tsx
@@ -44,7 +44,8 @@ export function ClaimPickupNoticeCard({
           <>
             <Text fontSize="sm" color="gray.600">
               Student notified to pick up in person at the {campusName} campus
-              security office.
+              security office. Approved claims expire automatically after 35
+              days if the item is not collected.
             </Text>
             <Text fontSize="sm" color="gray.700">
               <Text as="span" fontWeight="semibold">

--- a/foundit-ui/docs/notifications.md
+++ b/foundit-ui/docs/notifications.md
@@ -34,6 +34,7 @@ Routes/components:
 | Student cancels a claim                            | Active security/admin at the claim's campus                        | `claim_status_update` ("Claim Cancelled") |
 | Retention job expires items                        | Active security/admin at each affected campus (batched per campus) | `item_expiring`                           |
 | Retention job auto-rejects claims on expired items | Each affected student                                              | `claim_status_update`                     |
+| Open-claim expiry (35 days, unmatched)             | Student                                                            | `claim_status_update`                     |
 | Found-item report submitted                        | The finder                                                         | `report_confirmation`                     |
 
 Copy rule: messages name the item (`Your claim for "X" …`) and fall back to a

--- a/foundit-ui/docs/notifications.md
+++ b/foundit-ui/docs/notifications.md
@@ -1,7 +1,7 @@
 # Notifications — Flow & Status
 
 > Status doc for the **Notifications** feature (student + security). Reflects the
-> implementation as of 2026-07-13. Safe to commit/share (unlike the local-only
+> implementation as of 2026-08-05. Safe to commit/share (unlike the local-only
 > `plan.md` / `implementation.md`).
 
 ## 1. What it is
@@ -15,10 +15,12 @@ see per-campus alerts (new claims, cancellations, expired retention).
 Routes/components:
 
 - `app/profile/page.tsx` — tab switch; notifications tab renders the feed
-- `components/NotificationFeed.tsx` — heading, Unread filter, "Mark all as read", card list
-- `components/NotificationCard.tsx` — one row; circle button toggles read ⇄ unread
+- `components/NotificationFeed.tsx` — heading, All | Unread filter, "Mark all as read", card list
+- `components/NotificationCard.tsx` — card; left unread bar; mail toggle + dismiss
+- `utils/notificationHref.ts` — role-aware deep-link helper
 - `components/NotificationsProvider.tsx` — shares the unread count so the bell updates live
 - `components/Navbar.tsx` — bell icon + badge, links to the tab
+- `app/profile/page.tsx` — sidebar Notifications tab shows unread badge when count > 0
 - `hooks/useNotifications.ts` — data + optimistic read/unread actions
 - `lib/api/notifications.ts` / `types/notifications.ts` — API wrappers + shared types
 
@@ -55,14 +57,24 @@ way to query another user's notifications.
 
 ## 4. Feed interactions
 
-- **Card body click (or Enter/Space)** → mark read.
-- **Circle button** → toggles read ⇄ unread (`aria-label` flips accordingly).
-- **"Unread (N)"** → filters the list to unread cards (client-side — see gaps).
-- **"Mark all as read"** → clears everything unread server-side.
-- **Live badge**: `NotificationsProvider` (mounted in `RoleShell` and the
-  profile page) shares the count between feed and bell, so marking cards read
-  updates the badge without navigating. Navbar falls back to its own fetch when
-  no provider is mounted.
+- **Card click (or Enter/Space)** → optimistic mark read (fire-and-forget
+  PATCH), then navigate when `getNotificationHref` returns a path; otherwise
+  stay on the feed. Unread cards show a blue bar on the left edge.
+- **Deep links**:
+  - Student + claim → `/student/my-claims?claimId=` (opens existing claim modal)
+  - Security/admin + claim → `/security/claims/{id}`
+  - Security/admin + item → `/security/items/{id}`
+  - Security/admin + `item_expiring` → `/security/items?status=expired`
+  - Missing ref (other types) → no href (mark read only)
+- **Overflow / actions** → mail icon toggles read/unread; × dismisses. Relative
+  time sits under the message.
+- **All | Unread** → server filter via `?unreadOnly=true`. Under Unread, cards
+  marked read **stay rendered** until the filter changes, remount, or reload.
+- **"Mark all as read"** → clears everything unread server-side (cards stay on
+  the Unread view until refetch as above).
+- **Live badge**: `NotificationsProvider` shares the count between feed, navbar
+  account menu, and the profile sidebar Notifications tab. Navbar falls back to
+  its own fetch when no provider is mounted.
 
 ## 5. Error handling
 
@@ -75,12 +87,9 @@ way to query another user's notifications.
 
 ## 6. Known gaps / follow-ups (Phase 3+ of the roadmap)
 
-- No pagination; the **Unread filter is client-side** and only correct because
-  the full list loads in one request — move filtering server-side
-  (`?unreadOnly=true` exists) when pagination lands.
 - No retention/cleanup job for the notification table.
-- Clicking a card doesn't navigate to the referenced claim/item
-  (`referenceType`/`referenceId` are already returned by the API).
+- Soft-handling deleted claim deep links in the feed (destination pages already
+  404 / empty).
 - Email covers student claim events only (`deliverStudentClaimEmail` when
   `emailNotificationOptIn` + claim `notificationPreference` are set); security
   alerts, report confirmation, and retention expiry stay in-app.
@@ -88,9 +97,10 @@ way to query another user's notifications.
 
 ## 7. Tests
 
-- `tests/hooks/useNotifications.test.ts` — load, optimistic read/unread/all, rollbacks
-- `tests/components/NotificationFeed.test.tsx` — feed states, Unread filter, toggle wiring
-- `tests/components/NotificationCard.test.tsx` — card click/keyboard, circle toggle isolation
+- `tests/hooks/useNotifications.test.ts` — load, optimistic read/unread/all, rollbacks, stay-on-Unread
+- `tests/utils/notificationHref.test.ts` — role-aware href mapping
+- `tests/components/NotificationFeed.test.tsx` — feed states, All/Unread, open + navigate
+- `tests/components/NotificationCard.test.tsx` — card click/keyboard, read toggle, dismiss
 - `tests/components/Navbar.test.tsx` — bell + badge, guest fallback
 - Backend: `backend/tests/notifications.integration.test.ts` (routes, ownership,
   read/unread), fan-out cases in `claims.integration.test.ts` (submit + cancel),

--- a/foundit-ui/docs/security-item-detail.md
+++ b/foundit-ui/docs/security-item-detail.md
@@ -102,13 +102,7 @@ public one exists), `claims[]` (claimId / status / studentName), `campusId`,
 - Cancel navigates back to `/security/items`.
 - Responsive layout (fields beside photo on `lg`, stacked on mobile).
 
-**Working (since earlier stub notes)**
-
-- **Edit mode** — Save persists via `PATCH /api/items/:itemId`.
-- **Release** — walks to `/security/items/<id>/walk-in-release` (`POST .../walk-in-release`).
-- **Dispose** — `PATCH /api/items/:itemId/status` with `disposed` when allowed.
-
-**Still stubbed / unused in UI**
+**Stubbed / unused in UI**
 
 - **Finder** / **Finder Contact** — not shown (API may return `finder`; page does not render it).
 

--- a/foundit-ui/hooks/useNotifications.ts
+++ b/foundit-ui/hooks/useNotifications.ts
@@ -21,6 +21,11 @@ const PAGE_SIZE = 10;
  * server state on failure (by refetching). When a NotificationsProvider is
  * mounted, unread-count changes are mirrored into it so the navbar bell
  * updates live.
+ *
+ * When `unreadOnly` is true, marking a card read (or Mark all) does **not**
+ * remove it from the local list — read rows stay rendered until the filter
+ * changes, the feed remounts, or `reload()` runs. Server `unreadOnly` only
+ * applies on those refetches.
  */
 export function useNotifications(options?: { unreadOnly?: boolean }) {
   const unreadOnly = options?.unreadOnly ?? false;

--- a/foundit-ui/tests/components/NotificationCard.test.tsx
+++ b/foundit-ui/tests/components/NotificationCard.test.tsx
@@ -57,30 +57,33 @@ describe('NotificationCard', () => {
     expect(onClick).toHaveBeenCalledTimes(1);
   });
 
-  it('circle toggle fires onToggleRead without firing the card onClick', () => {
+  it('marks unread via the mail icon without firing card onClick', () => {
     const onClick = vi.fn();
-    const onToggleRead = vi.fn();
+    const onMarkUnread = vi.fn();
     renderWithProvider(
       <NotificationCard
         {...baseProps}
         isRead
         onClick={onClick}
-        onToggleRead={onToggleRead}
+        onMarkUnread={onMarkUnread}
       />
     );
 
     fireEvent.click(screen.getByRole('button', { name: 'Mark as unread' }));
 
-    expect(onToggleRead).toHaveBeenCalledTimes(1);
+    expect(onMarkUnread).toHaveBeenCalledTimes(1);
     expect(onClick).not.toHaveBeenCalled();
   });
 
-  it('labels the toggle "Mark as read" when the card is unread', () => {
+  it('marks read via the mail-open icon when unread', () => {
+    const onMarkRead = vi.fn();
     renderWithProvider(
-      <NotificationCard {...baseProps} isRead={false} onToggleRead={vi.fn()} />
+      <NotificationCard {...baseProps} isRead={false} onMarkRead={onMarkRead} />
     );
 
-    expect(screen.getByRole('button', { name: 'Mark as read' })).toBeDefined();
+    fireEvent.click(screen.getByRole('button', { name: 'Mark as read' }));
+
+    expect(onMarkRead).toHaveBeenCalledTimes(1);
   });
 
   it('dismiss fires onDismiss without firing the card onClick', () => {

--- a/foundit-ui/tests/components/NotificationFeed.test.tsx
+++ b/foundit-ui/tests/components/NotificationFeed.test.tsx
@@ -6,9 +6,24 @@ import { useNotifications } from '@/hooks/useNotifications';
 import type { AppNotification } from '@/types/notifications';
 import { renderWithProvider } from '../testUtils';
 
+const pushMock = vi.fn();
+
 vi.mock('@/hooks/useNotifications', () => ({
   useNotifications: vi.fn(),
 }));
+
+vi.mock('next/navigation', () => ({
+  useRouter: () => ({ push: pushMock }),
+}));
+
+vi.mock('@/utils/auth', async () => {
+  const actual =
+    await vi.importActual<typeof import('@/utils/auth')>('@/utils/auth');
+  return {
+    ...actual,
+    getSessionRole: vi.fn(() => 'student' as const),
+  };
+});
 
 const useNotificationsMock = vi.mocked(useNotifications);
 
@@ -33,6 +48,16 @@ const notifications: AppNotification[] = [
     isRead: true,
     createdAt: '2026-07-08T12:00:00.000Z',
   },
+  {
+    notificationId: 'n-3',
+    type: 'item_expiring',
+    title: 'Item retention expired',
+    message: '1 stored item reached the end of retention.',
+    referenceType: null,
+    referenceId: null,
+    isRead: false,
+    createdAt: '2026-07-07T12:00:00.000Z',
+  },
 ];
 
 function hookState(
@@ -40,7 +65,7 @@ function hookState(
 ): ReturnType<typeof useNotifications> {
   return {
     notifications,
-    unreadCount: 1,
+    unreadCount: 2,
     nextCursor: null,
     isLoading: false,
     isLoadingMore: false,
@@ -52,8 +77,6 @@ function hookState(
     loadMore: vi.fn(),
     reload: vi.fn(),
     ...overrides,
-    // Spread of Partial<> widens required fields to `| undefined`; assert the
-    // completed mock object back to the hook return type.
   } as ReturnType<typeof useNotifications>;
 }
 
@@ -62,37 +85,37 @@ beforeEach(() => {
 });
 
 describe('NotificationFeed', () => {
-  it('renders a card per notification with the unread count', () => {
+  it('renders a card per notification with All and Unread filters', () => {
     useNotificationsMock.mockReturnValue(hookState());
 
     renderWithProvider(<NotificationFeed />);
 
     expect(screen.getByText('New Claim Submitted')).toBeDefined();
     expect(screen.getByText('Match found')).toBeDefined();
-    expect(screen.getByText('Unread ( 1 )')).toBeDefined();
+    expect(screen.getByRole('button', { name: 'All' })).toBeDefined();
+    expect(screen.getByRole('button', { name: 'Unread 2' })).toBeDefined();
     expect(useNotificationsMock).toHaveBeenCalledWith({ unreadOnly: false });
   });
 
-  it('shows only Unread and Mark all as read in the toolbar', () => {
+  it('passes unreadOnly when Unread is selected', () => {
     useNotificationsMock.mockReturnValue(hookState());
 
     renderWithProvider(<NotificationFeed />);
-
-    expect(screen.getByRole('button', { name: 'Unread ( 1 )' })).toBeDefined();
-    expect(
-      screen.getByRole('button', { name: 'Mark all as read' })
-    ).toBeDefined();
-    expect(screen.queryByRole('button', { name: 'Select' })).toBeNull();
-    expect(screen.queryByRole('button', { name: /^Delete/ })).toBeNull();
-  });
-
-  it('passes unreadOnly when the Unread button is toggled', () => {
-    useNotificationsMock.mockReturnValue(hookState());
-
-    renderWithProvider(<NotificationFeed />);
-    fireEvent.click(screen.getByRole('button', { name: 'Unread ( 1 )' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Unread 2' }));
 
     expect(useNotificationsMock).toHaveBeenLastCalledWith({ unreadOnly: true });
+  });
+
+  it('returns to All when All is selected after Unread', () => {
+    useNotificationsMock.mockReturnValue(hookState());
+
+    renderWithProvider(<NotificationFeed />);
+    fireEvent.click(screen.getByRole('button', { name: 'Unread 2' }));
+    fireEvent.click(screen.getByRole('button', { name: 'All' }));
+
+    expect(useNotificationsMock).toHaveBeenLastCalledWith({
+      unreadOnly: false,
+    });
   });
 
   it('shows the filtered empty state when everything is read', () => {
@@ -104,23 +127,12 @@ describe('NotificationFeed', () => {
     );
 
     renderWithProvider(<NotificationFeed />);
-    fireEvent.click(screen.getByRole('button', { name: 'Unread ( 0 )' }));
+    fireEvent.click(screen.getByRole('button', { name: 'Unread 0' }));
 
     expect(screen.getByText('No unread notifications.')).toBeDefined();
   });
 
-  it("toggling a read card's circle calls markUnread", () => {
-    const state = hookState();
-    useNotificationsMock.mockReturnValue(state);
-
-    renderWithProvider(<NotificationFeed />);
-    fireEvent.click(screen.getByRole('button', { name: 'Mark as unread' }));
-
-    expect(state.markUnread).toHaveBeenCalledWith('n-2');
-    expect(state.markRead).not.toHaveBeenCalled();
-  });
-
-  it('marks a notification read when its card is clicked', async () => {
+  it('marks read and navigates when a linkable card is clicked', () => {
     const state = hookState();
     useNotificationsMock.mockReturnValue(state);
 
@@ -128,6 +140,18 @@ describe('NotificationFeed', () => {
     fireEvent.click(screen.getByText('New Claim Submitted'));
 
     expect(state.markRead).toHaveBeenCalledWith('n-1');
+    expect(pushMock).toHaveBeenCalledWith('/student/my-claims?claimId=c-1');
+  });
+
+  it('marks read without navigating for non-linkable cards', () => {
+    const state = hookState();
+    useNotificationsMock.mockReturnValue(state);
+
+    renderWithProvider(<NotificationFeed />);
+    fireEvent.click(screen.getByText('Item retention expired'));
+
+    expect(state.markRead).toHaveBeenCalledWith('n-3');
+    expect(pushMock).not.toHaveBeenCalled();
   });
 
   it('marks everything read via the header link', async () => {

--- a/foundit-ui/tests/hooks/useNotifications.test.ts
+++ b/foundit-ui/tests/hooks/useNotifications.test.ts
@@ -141,6 +141,26 @@ describe('useNotifications', () => {
     expect(markNotificationReadMock).toHaveBeenCalledWith('n-1');
   });
 
+  it('keeps read rows in the list when unreadOnly is true', async () => {
+    fetchNotificationsMock.mockResolvedValue({
+      notifications: [unread],
+      unreadCount: 1,
+      nextCursor: null,
+    });
+    markNotificationReadMock.mockResolvedValue({ ...unread, isRead: true });
+
+    const { result } = renderHook(() => useNotifications({ unreadOnly: true }));
+    await waitFor(() => expect(result.current.isLoading).toBe(false));
+
+    await act(() => result.current.markRead('n-1'));
+
+    expect(result.current.notifications).toHaveLength(1);
+    expect(result.current.notifications[0]?.isRead).toBe(true);
+    expect(result.current.unreadCount).toBe(0);
+    // No client-side filter-out — only the initial unreadOnly fetch.
+    expect(fetchNotificationsMock).toHaveBeenCalledTimes(1);
+  });
+
   it('skips the request for an already-read notification', async () => {
     const { result } = renderHook(() => useNotifications());
     await waitFor(() => expect(result.current.isLoading).toBe(false));

--- a/foundit-ui/utils/notificationHref.ts
+++ b/foundit-ui/utils/notificationHref.ts
@@ -1,0 +1,44 @@
+import type { AppNotification } from '@/types/notifications';
+import { buildSecurityItemsHref } from '@/utils/claimDisplay';
+import type { UserRole } from '@/utils/routes';
+
+/**
+ * Resolves where a notification card should navigate on open.
+ * Returns null when there is no useful destination for the role.
+ */
+export function getNotificationHref(
+  notification: Pick<AppNotification, 'type' | 'referenceType' | 'referenceId'>,
+  role: UserRole | null
+): string | null {
+  // Batched retention notices have no single item id — open the expired filter.
+  if (notification.type === 'item_expiring') {
+    if (role === 'security' || role === 'admin') {
+      return buildSecurityItemsHref({ status: 'expired' });
+    }
+    return null;
+  }
+
+  const { referenceType, referenceId } = notification;
+  if (!referenceType || !referenceId) {
+    return null;
+  }
+
+  if (referenceType === 'claim') {
+    if (role === 'student') {
+      return `/student/my-claims?claimId=${encodeURIComponent(referenceId)}`;
+    }
+    if (role === 'security' || role === 'admin') {
+      return `/security/claims/${encodeURIComponent(referenceId)}`;
+    }
+    return null;
+  }
+
+  if (referenceType === 'item') {
+    if (role === 'security' || role === 'admin') {
+      return `/security/items/${encodeURIComponent(referenceId)}`;
+    }
+    return null;
+  }
+
+  return null;
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Claims left submitted or under review for more than 35 days now expire automatically, with suggested matches dismissed and students notified.
  - Notifications support All/Unread filters, direct navigation, unread badges, and clearer read/unread controls.
  - Claim details can open directly from shared links.
  - Approved claims now display the 35-day pickup expiration policy.

- **Bug Fixes**
  - Read notifications remain visible while browsing the unread filter.
  - New self-registrations consistently receive the student role.

- **Documentation**
  - Updated notification behavior, claim expiration, and item-detail status documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->